### PR TITLE
Add traits for String and str

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Rust Inflector
 
-[![Build
-Status](https://travis-ci.org/whatisinternet/inflector.svg)](https://travis-ci.org/whatisinternet/inflector)
+[![Build Status](https://travis-ci.org/whatisinternet/inflector.svg?branch=master)](https://travis-ci.org/whatisinternet/inflector)
 
 Adds String based inflections for Rust. Snake, kebab, camel,
 sentence, class, title, upper, and lower cases are supported as both traits and

--- a/README.md
+++ b/README.md
@@ -3,20 +3,14 @@
 [![Build
 Status](https://travis-ci.org/whatisinternet/inflector.svg)](https://travis-ci.org/whatisinternet/inflector)
 
-Provides ActiveSupport style inflection for Rust. Still very much a work in
-progress.
-
-Unlike ActiveSupport in Rails: Any supported case will be able to transition into any other supported case. For example:
-
-```rust
-...
-let class_cased: String = to_upper_case(to_lower_case(to_class_case(to_camel_case(to_snake_case(to_kebab_case("SomeString")))))); //-> "SOMESTRING"
-...
-```
+Adds String based inflections for Rust. Support for snake, kebab, camel,
+sentence, class, title, upper, and lower cases are supported as both traits and
+pure functions acting on String types.
 
 -----
 ## TODO:
 
+- [x] Traits for String
 - [x] Snake case
 - [x] Kebab case
 - [x] Camel case
@@ -78,6 +72,10 @@ use inflector::*;
 fn main() {
 ...
   let camel_case_string: String = to_camel_case("some_string".to_string());
+...
+// Or
+...
+  let camel_case_string: String = "some_string".to_string().to_camel_case();
 ...
 }
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build
 Status](https://travis-ci.org/whatisinternet/inflector.svg)](https://travis-ci.org/whatisinternet/inflector)
 
-Adds String based inflections for Rust. Support for snake, kebab, camel,
+Adds String based inflections for Rust. Snake, kebab, camel,
 sentence, class, title, upper, and lower cases are supported as both traits and
 pure functions acting on String types.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ pure functions acting on String types.
 ## TODO:
 
 - [x] Traits for String
+- [x] Traits for str
 - [x] Snake case
 - [x] Kebab case
 - [x] Camel case

--- a/src/cases/camelcase/camelcase_test.rs
+++ b/src/cases/camelcase/camelcase_test.rs
@@ -49,6 +49,14 @@ fn camelize_DataMapper_as_dataMapper() {
 }
 
 #[test] #[allow(non_snake_case)]
+fn camelize_DataMapper3_as_dataMapper3() {
+    let mock_string: String = "DataMapper3".to_string();
+    let expected_string: String = "dataMapper3".to_string();
+    let asserted_string: String = to_camel_case(mock_string);
+    assert!(asserted_string == expected_string);
+}
+
+#[test] #[allow(non_snake_case)]
 fn returns_falsey_value_for_is_camel_case_when_kebab() {
     let mock_string: String = "data-mapper-string-that-is-really-really-long".to_string();
     let asserted_bool: bool = is_camel_case(mock_string);
@@ -60,6 +68,13 @@ fn returns_falsey_value_for_is_camel_case_when_class() {
     let mock_string: String = "DataMapperIsAReallyReallyLongString".to_string();
     let asserted_bool: bool = is_camel_case(mock_string);
     assert!(asserted_bool == false);
+}
+
+#[test] #[allow(non_snake_case)]
+fn returns_truthy_value_for_is_camel_case_when_camel_with_number() {
+    let mock_string: String = "dataMapperIsAReallyReally3LongString".to_string();
+    let asserted_bool: bool = is_camel_case(mock_string);
+    assert!(asserted_bool == true);
 }
 
 #[test] #[allow(non_snake_case)]

--- a/src/cases/snakecase/snakecase_test.rs
+++ b/src/cases/snakecase/snakecase_test.rs
@@ -43,6 +43,20 @@ fn returns_truthy_value_for_is_snake_case_when_snake() {
 }
 
 #[test] #[allow(non_snake_case)]
+fn returns_truthy_value_for_is_snake_case_when_snake_with_a_number() {
+    let mock_string: String = "data_mapper1_string_that_is_really_really_long".to_string();
+    let asserted_bool: bool = is_snake_case(mock_string);
+    assert!(asserted_bool == true);
+}
+
+#[test] #[allow(non_snake_case)]
+fn returns_truthy_value_for_is_snake_case_when_snake_with_a_number_snaked() {
+    let mock_string: String = "data_mapper_1_string_that_is_really_really_long".to_string();
+    let asserted_bool: bool = is_snake_case(mock_string);
+    assert!(asserted_bool == true);
+}
+
+#[test] #[allow(non_snake_case)]
 fn snake_case_data_mapper_as_data_mapper() {
     let mock_string: String = "data_mapper".to_string();
     let expected_string: String = "data_mapper".to_string();
@@ -78,6 +92,14 @@ fn snake_case_DataMapper_as_data_mapper() {
 fn snake_case_dataMapper_as_data_mapper() {
     let mock_string: String = "dataMapper".to_string();
     let expected_string: String = "data_mapper".to_string();
+    let asserted_string: String = to_snake_case(mock_string);
+    assert!(asserted_string == expected_string);
+}
+
+#[test] #[allow(non_snake_case)]
+fn snake_case_dataMapper3_as_data_mapper() {
+    let mock_string: String = "dataMapper3".to_string();
+    let expected_string: String = "data_mapper_3".to_string();
     let asserted_string: String = to_snake_case(mock_string);
     assert!(asserted_string == expected_string);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,8 @@ use cases::lowercase::is_lower_case;
 
 
 pub trait Inflector {
-    fn to_class_case<'c>(&self) -> String;
-    fn is_class_case<'c>(&self) -> bool;
+    fn to_class_case<'a>(&self) -> String;
+    fn is_class_case<'a>(&self) -> bool;
 
     fn to_camel_case<'a>(&self) -> String;
     fn is_camel_case<'a>(&self) -> bool;
@@ -104,82 +104,213 @@ impl<'c> Inflector for String {
     }
 }
 
+impl<'c> Inflector for str {
+    fn to_class_case(&self) -> String{
+        return to_class_case(self.to_string());
+    }
+    fn is_class_case(&self) -> bool{
+        return is_class_case(self.to_string());
+    }
+    fn to_camel_case(&self) -> String{
+        return to_camel_case(self.to_string());
+    }
+    fn is_camel_case(&self) -> bool{
+        return is_camel_case(self.to_string());
+    }
+    fn to_snake_case(&self) -> String{
+        return to_snake_case(self.to_string());
+    }
+    fn is_snake_case(&self) -> bool{
+        return is_snake_case(self.to_string());
+    }
+    fn to_kebab_case(&self) -> String{
+        return to_kebab_case(self.to_string());
+    }
+    fn is_kebab_case(&self) -> bool{
+        return is_kebab_case(self.to_string());
+    }
+    fn to_sentence_case(&self) -> String{
+        return to_sentence_case(self.to_string());
+    }
+    fn is_sentence_case(&self) -> bool{
+        return is_sentence_case(self.to_string());
+    }
+    fn to_title_case(&self) -> String{
+        return to_title_case(self.to_string());
+    }
+    fn is_title_case(&self) -> bool{
+        return is_title_case(self.to_string());
+    }
+    fn to_upper_case(&self) -> String{
+        return to_upper_case(self.to_string());
+    }
+    fn is_upper_case(&self) -> bool{
+        return is_upper_case(self.to_string());
+    }
+    fn to_lower_case(&self) -> String{
+        return to_lower_case(self.to_string());
+    }
+    fn is_lower_case(&self) -> bool{
+        return is_lower_case(self.to_string());
+    }
+}
+
 #[test]
-fn trait_to_class_case() {
+fn string_trait_to_class_case() {
     assert_eq!("foo".to_string().to_class_case(), "Foo".to_string());
 }
 
 #[test]
-fn trait_is_class_case() {
+fn string_trait_is_class_case() {
     assert_eq!("FooFoo".to_string().is_class_case(), true);
 }
 
 #[test]
-fn trait_to_camel_case() {
+fn string_trait_to_camel_case() {
     assert_eq!("fooFoo".to_string().to_camel_case(), "fooFoo".to_string());
 }
 
 #[test]
-fn trait_is_camel_case() {
+fn string_trait_is_camel_case() {
     assert_eq!("fooFoo".to_string().is_camel_case(), true);
 }
 
 #[test]
-fn trait_to_snake_case() {
+fn string_trait_to_snake_case() {
     assert_eq!("fooFoo".to_string().to_snake_case(), "foo_foo".to_string());
 }
 
 #[test]
-fn trait_issnake_case() {
+fn string_trait_is_snake_case() {
     assert_eq!("foo_foo".to_string().is_snake_case(), true);
 }
 
 #[test]
-fn trait_to_kebab_case() {
+fn string_trait_to_kebab_case() {
     assert_eq!("fooFoo".to_string().to_kebab_case(), "foo-foo".to_string());
 }
 
 #[test]
-fn trait_is_kebab_case() {
+fn string_trait_is_kebab_case() {
     assert_eq!("foo-foo".to_string().is_kebab_case(), true);
 }
 
 #[test]
-fn trait_to_sentence_case() {
+fn string_trait_to_sentence_case() {
     assert_eq!("fooFoo".to_string().to_sentence_case(), "Foo foo".to_string());
 }
 
 #[test]
-fn trait_is_sentence_case() {
+fn string_trait_is_sentence_case() {
     assert_eq!("Foo foo".to_string().is_sentence_case(), true);
 }
 
 #[test]
-fn trait_to_title_case() {
+fn string_trait_to_title_case() {
     assert_eq!("fooFoo".to_string().to_title_case(), "Foo Foo".to_string());
 }
 
 #[test]
-fn trait_is_title_case() {
+fn string_trait_is_title_case() {
     assert_eq!("Foo Foo".to_string().is_title_case(), true);
 }
 
 #[test]
-fn trait_to_upper_case() {
+fn string_trait_to_upper_case() {
     assert_eq!("fooFoo".to_string().to_upper_case(), "FOOFOO".to_string());
 }
 
 #[test]
-fn trait_is_upper_case() {
+fn string_trait_is_upper_case() {
     assert_eq!("FOOFOO".to_string().is_upper_case(), true);
 }
 
 #[test]
-fn trait_to_lower_case() {
+fn string_trait_to_lower_case() {
     assert_eq!("fooFoo".to_string().to_lower_case(), "foofoo".to_string());
 }
 
 #[test]
-fn trait_is_lower_case() {
+fn string_trait_is_lower_case() {
     assert_eq!("foo".to_string().is_lower_case(), true);
+}
+
+#[test]
+fn str_trait_to_class_case() {
+    assert_eq!("foo".to_class_case(), "Foo".to_string());
+}
+
+#[test]
+fn str_trait_is_class_case() {
+    assert_eq!("FooFoo".is_class_case(), true);
+}
+
+#[test]
+fn str_trait_to_camel_case() {
+    assert_eq!("fooFoo".to_camel_case(), "fooFoo".to_string());
+}
+
+#[test]
+fn str_trait_is_camel_case() {
+    assert_eq!("fooFoo".is_camel_case(), true);
+}
+
+#[test]
+fn str_trait_to_snake_case() {
+    assert_eq!("fooFoo".to_snake_case(), "foo_foo".to_string());
+}
+
+#[test]
+fn str_trait_is_snake_case() {
+    assert_eq!("foo_foo".is_snake_case(), true);
+}
+
+#[test]
+fn str_trait_to_kebab_case() {
+    assert_eq!("fooFoo".to_kebab_case(), "foo-foo".to_string());
+}
+
+#[test]
+fn str_trait_is_kebab_case() {
+    assert_eq!("foo-foo".is_kebab_case(), true);
+}
+
+#[test]
+fn str_trait_to_sentence_case() {
+    assert_eq!("fooFoo".to_sentence_case(), "Foo foo".to_string());
+}
+
+#[test]
+fn str_trait_is_sentence_case() {
+    assert_eq!("Foo foo".is_sentence_case(), true);
+}
+
+#[test]
+fn str_trait_to_title_case() {
+    assert_eq!("fooFoo".to_title_case(), "Foo Foo".to_string());
+}
+
+#[test]
+fn str_trait_is_title_case() {
+    assert_eq!("Foo Foo".is_title_case(), true);
+}
+
+#[test]
+fn str_trait_to_upper_case() {
+    assert_eq!("fooFoo".to_upper_case(), "FOOFOO".to_string());
+}
+
+#[test]
+fn str_trait_is_upper_case() {
+    assert_eq!("FOOFOO".is_upper_case(), true);
+}
+
+#[test]
+fn str_trait_to_lower_case() {
+    assert_eq!("fooFoo".to_lower_case(), "foofoo".to_string());
+}
+
+#[test]
+fn str_trait_is_lower_case() {
+    assert_eq!("foo".is_lower_case(), true);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,23 +2,184 @@ extern crate regex;
 
 pub mod cases;
 
-// use cases::classcase::to_class_case;
-// use cases::classcase::is_class_case;
-//
-// use cases::camelcase::to_camel_case;
-// use cases::camelcase::is_camel_case;
-//
-// use cases::snakecase::to_snake_case;
-// use cases::snakecase::is_snake_case;
-//
-// use cases::kebabcase::to_kebab_case;
-// use cases::kebabcase::is_kebab_case;
-//
-// use cases::sentencecase::to_sentence_case;
-// use cases::sentencecase::is_sentence_case;
-//
-// use cases::uppercase::to_upper_case;
-// use cases::uppercase::is_upper_case;
-//
-// use cases::lowercase::to_lower_case;
-// use cases::lowercase::is_lower_case;
+use cases::classcase::to_class_case;
+use cases::classcase::is_class_case;
+
+use cases::camelcase::to_camel_case;
+use cases::camelcase::is_camel_case;
+
+use cases::snakecase::to_snake_case;
+use cases::snakecase::is_snake_case;
+
+use cases::kebabcase::to_kebab_case;
+use cases::kebabcase::is_kebab_case;
+
+use cases::sentencecase::to_sentence_case;
+use cases::sentencecase::is_sentence_case;
+
+use cases::titlecase::to_title_case;
+use cases::titlecase::is_title_case;
+
+use cases::uppercase::to_upper_case;
+use cases::uppercase::is_upper_case;
+
+use cases::lowercase::to_lower_case;
+use cases::lowercase::is_lower_case;
+
+
+pub trait Inflector {
+    fn to_class_case<'c>(&self) -> String;
+    fn is_class_case<'c>(&self) -> bool;
+
+    fn to_camel_case<'a>(&self) -> String;
+    fn is_camel_case<'a>(&self) -> bool;
+
+    fn to_snake_case<'a>(&self) -> String;
+    fn is_snake_case<'a>(&self) -> bool;
+
+    fn to_kebab_case<'a>(&self) -> String;
+    fn is_kebab_case<'a>(&self) -> bool;
+
+    fn to_sentence_case<'a>(&self) -> String;
+    fn is_sentence_case<'a>(&self) -> bool;
+
+    fn to_title_case<'a>(&self) -> String;
+    fn is_title_case<'a>(&self) -> bool;
+
+    fn to_upper_case<'a>(&self) -> String;
+    fn is_upper_case<'a>(&self) -> bool;
+
+    fn to_lower_case<'a>(&self) -> String;
+    fn is_lower_case<'a>(&self) -> bool;
+}
+
+impl<'c> Inflector for String {
+    fn to_class_case(&self) -> String{
+        return to_class_case(self.to_string());
+    }
+    fn is_class_case(&self) -> bool{
+        return is_class_case(self.to_string());
+    }
+    fn to_camel_case(&self) -> String{
+        return to_camel_case(self.to_string());
+    }
+    fn is_camel_case(&self) -> bool{
+        return is_camel_case(self.to_string());
+    }
+    fn to_snake_case(&self) -> String{
+        return to_snake_case(self.to_string());
+    }
+    fn is_snake_case(&self) -> bool{
+        return is_snake_case(self.to_string());
+    }
+    fn to_kebab_case(&self) -> String{
+        return to_kebab_case(self.to_string());
+    }
+    fn is_kebab_case(&self) -> bool{
+        return is_kebab_case(self.to_string());
+    }
+    fn to_sentence_case(&self) -> String{
+        return to_sentence_case(self.to_string());
+    }
+    fn is_sentence_case(&self) -> bool{
+        return is_sentence_case(self.to_string());
+    }
+    fn to_title_case(&self) -> String{
+        return to_title_case(self.to_string());
+    }
+    fn is_title_case(&self) -> bool{
+        return is_title_case(self.to_string());
+    }
+    fn to_upper_case(&self) -> String{
+        return to_upper_case(self.to_string());
+    }
+    fn is_upper_case(&self) -> bool{
+        return is_upper_case(self.to_string());
+    }
+    fn to_lower_case(&self) -> String{
+        return to_lower_case(self.to_string());
+    }
+    fn is_lower_case(&self) -> bool{
+        return is_lower_case(self.to_string());
+    }
+}
+
+#[test]
+fn trait_to_class_case() {
+    assert_eq!("foo".to_string().to_class_case(), "Foo".to_string());
+}
+
+#[test]
+fn trait_is_class_case() {
+    assert_eq!("FooFoo".to_string().is_class_case(), true);
+}
+
+#[test]
+fn trait_to_camel_case() {
+    assert_eq!("fooFoo".to_string().to_camel_case(), "fooFoo".to_string());
+}
+
+#[test]
+fn trait_is_camel_case() {
+    assert_eq!("fooFoo".to_string().is_camel_case(), true);
+}
+
+#[test]
+fn trait_to_snake_case() {
+    assert_eq!("fooFoo".to_string().to_snake_case(), "foo_foo".to_string());
+}
+
+#[test]
+fn trait_issnake_case() {
+    assert_eq!("foo_foo".to_string().is_snake_case(), true);
+}
+
+#[test]
+fn trait_to_kebab_case() {
+    assert_eq!("fooFoo".to_string().to_kebab_case(), "foo-foo".to_string());
+}
+
+#[test]
+fn trait_is_kebab_case() {
+    assert_eq!("foo-foo".to_string().is_kebab_case(), true);
+}
+
+#[test]
+fn trait_to_sentence_case() {
+    assert_eq!("fooFoo".to_string().to_sentence_case(), "Foo foo".to_string());
+}
+
+#[test]
+fn trait_is_sentence_case() {
+    assert_eq!("Foo foo".to_string().is_sentence_case(), true);
+}
+
+#[test]
+fn trait_to_title_case() {
+    assert_eq!("fooFoo".to_string().to_title_case(), "Foo Foo".to_string());
+}
+
+#[test]
+fn trait_is_title_case() {
+    assert_eq!("Foo Foo".to_string().is_title_case(), true);
+}
+
+#[test]
+fn trait_to_upper_case() {
+    assert_eq!("fooFoo".to_string().to_upper_case(), "FOOFOO".to_string());
+}
+
+#[test]
+fn trait_is_upper_case() {
+    assert_eq!("FOOFOO".to_string().is_upper_case(), true);
+}
+
+#[test]
+fn trait_to_lower_case() {
+    assert_eq!("fooFoo".to_string().to_lower_case(), "foofoo".to_string());
+}
+
+#[test]
+fn trait_is_lower_case() {
+    assert_eq!("foo".to_string().is_lower_case(), true);
+}


### PR DESCRIPTION
# What it does:
- Adds traits for String
```rust
let temp: String= "temp".to_string().to_upper_case();
```
- Adds traits for str
```rust
let temp: String = "temp".to_upper_case();
```
- Adds tests for numbers integrated into strings.

# Why it does it:
- Being able to call dot something is the expected behaviour for libraries in rust of this type.

# Downsides:
- This forces a string back as the return value. The user can actually overcome this by recasting using &foobar if an actual str is needed.

# References used:
- [Rust changecase](https://github.com/vlad003/rust-changecase)