### PR TITLE
Add foreign key, demodulize, and deconstantize.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Adds String based inflections for Rust. Snake, kebab, camel,
 sentence, class, title, upper, and lower cases as well as ordinalize,
-deordinalize, and foreign key are supported as both traits and pure functions
+deordinalize, demodulize, and foreign key are supported as both traits and pure functions
 acting on String types.
 
 -----
@@ -22,7 +22,7 @@ acting on String types.
 - [x] Lower case
 - [x] Ordinalize and reverse
 - [x] Foreign key
-- [ ] Demodulize
+- [x] Demodulize
 - [ ] Pluralize
 - [ ] Singularize
 - [ ] Table case
@@ -77,7 +77,10 @@ use inflector::*;
 // use inflector::numbers::deordinalize::deordinalize;
 
 // use inflector::suffix::foreignkey::to_foreign_key;
+// use inflector::suffix::foreignkey::is_foreign_key;
 
+// use inflector::string::demodulize::demodulize;
+// use inflector::string::deconstantize::deconstantize;
 ...
 fn main() {
 ...
@@ -132,6 +135,14 @@ ordinalize(String) -> String
 
 ```rust
 deordinalize(String) -> String
+```
+
+```rust
+demodulize(String) -> String
+```
+
+```rust
+deconstantize(String) -> String
 ```
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Build Status](https://travis-ci.org/whatisinternet/inflector.svg?branch=master)](https://travis-ci.org/whatisinternet/inflector)
 
 Adds String based inflections for Rust. Snake, kebab, camel,
-sentence, class, title, upper, and lower cases as well as ordinalize and
-deordinalize  are supported as both traits and pure functions acting on String
- types.
+sentence, class, title, upper, and lower cases as well as ordinalize,
+deordinalize, and foreign key are supported as both traits and pure functions
+acting on String types.
 
 -----
 ## TODO:
@@ -21,7 +21,8 @@ deordinalize  are supported as both traits and pure functions acting on String
 - [x] Upper case
 - [x] Lower case
 - [x] Ordinalize and reverse
-- [ ] Foreign key
+- [x] Foreign key
+- [ ] Demodulize
 - [ ] Pluralize
 - [ ] Singularize
 - [ ] Table case
@@ -74,6 +75,8 @@ use inflector::*;
 
 // use inflector::numbers::ordinalize::ordinalize;
 // use inflector::numbers::deordinalize::deordinalize;
+
+// use inflector::suffix::foreignkey::to_foreign_key;
 
 ...
 fn main() {
@@ -132,6 +135,11 @@ deordinalize(String) -> String
 ```
 
 ```rust
+to_foreign_key(String) -> String
+```
+
+
+```rust
 is_class_case(String) -> bool
 ```
 
@@ -161,6 +169,10 @@ is_upper_case(String) -> bool
 
 ```rust
 is_lower_case(String) -> bool
+```
+
+```rust
+is_foreign_key(String) -> bool
 ```
 
 ## Contributing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ extern crate regex;
 pub mod cases;
 pub mod numbers;
 pub mod suffix;
+pub mod string;
 
 use cases::classcase::to_class_case;
 use cases::classcase::is_class_case;
@@ -33,6 +34,9 @@ use numbers::deordinalize::deordinalize;
 
 use suffix::foreignkey::to_foreign_key;
 use suffix::foreignkey::is_foreign_key;
+
+use string::demodulize::demodulize;
+use string::deconstantize::deconstantize;
 
 
 pub trait Inflector {
@@ -65,6 +69,9 @@ pub trait Inflector {
 
     fn to_foreign_key<'a>(&self) -> String;
     fn is_foreign_key<'a>(&self) -> bool;
+
+    fn demodulize<'a>(&self) -> String;
+    fn deconstantize<'a>(&self) -> String;
 }
 
 impl<'c> Inflector for String {
@@ -128,6 +135,12 @@ impl<'c> Inflector for String {
     fn is_foreign_key(&self) -> bool{
         return is_foreign_key(self.to_string());
     }
+    fn demodulize(&self) -> String{
+        return demodulize(self.to_string());
+    }
+    fn deconstantize(&self) -> String{
+        return deconstantize(self.to_string());
+    }
 }
 
 impl<'c> Inflector for str {
@@ -190,6 +203,12 @@ impl<'c> Inflector for str {
     }
     fn is_foreign_key(&self) -> bool{
         return is_foreign_key(self.to_string());
+    }
+    fn demodulize(&self) -> String{
+        return demodulize(self.to_string());
+    }
+    fn deconstantize(&self) -> String{
+        return deconstantize(self.to_string());
     }
 }
 
@@ -289,6 +308,16 @@ fn string_trait_to_foreign_key() {
 }
 
 #[test]
+fn string_trait_demodulize() {
+    assert_eq!("Foo::Bar".to_string().demodulize(), "Bar".to_string());
+}
+
+#[test]
+fn string_trait_deconstantize() {
+    assert_eq!("Foo::Bar".to_string().deconstantize(), "Foo".to_string());
+}
+
+#[test]
 fn str_trait_to_class_case() {
     assert_eq!("foo".to_class_case(), "Foo".to_string());
 }
@@ -381,4 +410,14 @@ fn str_trait_deordinalize() {
 #[test]
 fn str_trait_to_foreign_key() {
     assert_eq!("Foo::Bar".to_foreign_key(), "bar_id".to_string());
+}
+
+#[test]
+fn str_trait_demodulize() {
+    assert_eq!("Foo::Bar".demodulize(), "Bar".to_string());
+}
+
+#[test]
+fn str_trait_deconstantize() {
+    assert_eq!("Foo::Bar".deconstantize(), "Foo".to_string());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ extern crate regex;
 
 pub mod cases;
 pub mod numbers;
+pub mod suffix;
 
 use cases::classcase::to_class_case;
 use cases::classcase::is_class_case;
@@ -29,6 +30,9 @@ use cases::lowercase::is_lower_case;
 
 use numbers::ordinalize::ordinalize;
 use numbers::deordinalize::deordinalize;
+
+use suffix::foreignkey::to_foreign_key;
+use suffix::foreignkey::is_foreign_key;
 
 
 pub trait Inflector {
@@ -58,6 +62,9 @@ pub trait Inflector {
 
     fn ordinalize<'a>(&self) -> String;
     fn deordinalize<'a>(&self) -> String;
+
+    fn to_foreign_key<'a>(&self) -> String;
+    fn is_foreign_key<'a>(&self) -> bool;
 }
 
 impl<'c> Inflector for String {
@@ -115,6 +122,12 @@ impl<'c> Inflector for String {
     fn deordinalize(&self) -> String{
         return deordinalize(self.to_string());
     }
+    fn to_foreign_key(&self) -> String{
+        return to_foreign_key(self.to_string());
+    }
+    fn is_foreign_key(&self) -> bool{
+        return is_foreign_key(self.to_string());
+    }
 }
 
 impl<'c> Inflector for str {
@@ -171,6 +184,12 @@ impl<'c> Inflector for str {
     }
     fn deordinalize(&self) -> String{
         return deordinalize(self.to_string());
+    }
+    fn to_foreign_key(&self) -> String{
+        return to_foreign_key(self.to_string());
+    }
+    fn is_foreign_key(&self) -> bool{
+        return is_foreign_key(self.to_string());
     }
 }
 
@@ -265,6 +284,11 @@ fn string_trait_deordinalize() {
 }
 
 #[test]
+fn string_trait_to_foreign_key() {
+    assert_eq!("Foo::Bar".to_string().to_foreign_key(), "bar_id".to_string());
+}
+
+#[test]
 fn str_trait_to_class_case() {
     assert_eq!("foo".to_class_case(), "Foo".to_string());
 }
@@ -352,4 +376,9 @@ fn str_trait_ordinalize() {
 #[test]
 fn str_trait_deordinalize() {
     assert_eq!("1st".deordinalize(), "1".to_string());
+}
+
+#[test]
+fn str_trait_to_foreign_key() {
+    assert_eq!("Foo::Bar".to_foreign_key(), "bar_id".to_string());
 }

--- a/src/string/deconstantize/deconstantize_test.rs
+++ b/src/string/deconstantize/deconstantize_test.rs
@@ -1,0 +1,34 @@
+use string::deconstantize::*;
+
+#[test] #[allow(non_snake_case)]
+fn deconstantize_Mapper_as_Mapper() {
+    let mock_string: String = "Mapper".to_string();
+    let expected_string: String = "".to_string();
+    let asserted_string: String = deconstantize(mock_string);
+    assert!(asserted_string == expected_string);
+}
+
+#[test] #[allow(non_snake_case)]
+fn deconstantize_namespace_Mapper_as_Mapper() {
+    let mock_string: String = "::Mapper".to_string();
+    let expected_string: String = "".to_string();
+    let asserted_string: String = deconstantize(mock_string);
+    assert!(asserted_string == expected_string);
+}
+
+#[test] #[allow(non_snake_case)]
+fn deconstantize_Data_namespace_Mapper_as_Mapper() {
+    let mock_string: String = "Data::Mapper".to_string();
+    let expected_string: String = "Data".to_string();
+    let asserted_string: String = deconstantize(mock_string);
+    assert!(asserted_string == expected_string);
+}
+
+#[test] #[allow(non_snake_case)]
+fn deconstantize_Test_namespace_Data_namespace_Mapper_as_Mapper() {
+    let mock_string: String = "Test::Data::Mapper".to_string();
+    let expected_string: String = "Data".to_string();
+    let asserted_string: String = deconstantize(mock_string);
+    assert!(asserted_string == expected_string);
+}
+

--- a/src/string/deconstantize/mod.rs
+++ b/src/string/deconstantize/mod.rs
@@ -1,0 +1,17 @@
+use cases::classcase::to_class_case;
+
+pub fn deconstantize<'a>(non_deconstantized_string: String) -> String {
+    if non_deconstantized_string.contains("::") {
+        let split_string: Vec<&str> = non_deconstantized_string.split("::").collect();
+        if split_string.len() > 1 {
+            return format!("{}", to_class_case(split_string[split_string.len() - 2].to_string()));
+        } else {
+            return "".to_string();
+        }
+    } else {
+        return "".to_string();
+    }
+}
+
+#[cfg(test)]
+mod deconstantize_test;

--- a/src/string/demodulize/demodulize_test.rs
+++ b/src/string/demodulize/demodulize_test.rs
@@ -1,0 +1,34 @@
+use string::demodulize::*;
+
+#[test] #[allow(non_snake_case)]
+fn demodulize_Mapper_as_Mapper() {
+    let mock_string: String = "Mapper".to_string();
+    let expected_string: String = "Mapper".to_string();
+    let asserted_string: String = demodulize(mock_string);
+    assert!(asserted_string == expected_string);
+}
+
+#[test] #[allow(non_snake_case)]
+fn demodulize_namespace_Mapper_as_Mapper() {
+    let mock_string: String = "::Mapper".to_string();
+    let expected_string: String = "Mapper".to_string();
+    let asserted_string: String = demodulize(mock_string);
+    assert!(asserted_string == expected_string);
+}
+
+#[test] #[allow(non_snake_case)]
+fn demodulize_Data_namespace_Mapper_as_Mapper() {
+    let mock_string: String = "Data::Mapper".to_string();
+    let expected_string: String = "Mapper".to_string();
+    let asserted_string: String = demodulize(mock_string);
+    assert!(asserted_string == expected_string);
+}
+
+#[test] #[allow(non_snake_case)]
+fn demodulize_Test_namespace_Data_namespace_Mapper_as_Mapper() {
+    let mock_string: String = "Test::Data::Mapper".to_string();
+    let expected_string: String = "Mapper".to_string();
+    let asserted_string: String = demodulize(mock_string);
+    assert!(asserted_string == expected_string);
+}
+

--- a/src/string/demodulize/mod.rs
+++ b/src/string/demodulize/mod.rs
@@ -1,0 +1,13 @@
+use cases::classcase::to_class_case;
+
+pub fn demodulize<'a>(non_demodulize_string: String) -> String {
+    if non_demodulize_string.contains("::") {
+        let split_string: Vec<&str> = non_demodulize_string.split("::").collect();
+        return format!("{}", to_class_case(split_string[split_string.len() - 1].to_string()));
+    } else {
+        return non_demodulize_string;
+    }
+}
+
+#[cfg(test)]
+mod demodulize_test;

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -1,0 +1,2 @@
+pub mod demodulize;
+pub mod deconstantize;

--- a/src/suffix/foreignkey/foreignkey_test.rs
+++ b/src/suffix/foreignkey/foreignkey_test.rs
@@ -1,0 +1,114 @@
+use suffix::foreignkey::*;
+
+#[test] #[allow(non_snake_case)]
+fn returns_falsey_value_for_is_foreign_key_when_sentence() {
+    let mock_string: String = "Data mapper string that is really really long".to_string();
+    let asserted_bool: bool = is_foreign_key(mock_string);
+    assert!(asserted_bool == false);
+}
+
+#[test] #[allow(non_snake_case)]
+fn returns_falsey_value_for_is_foreign_key_when_kebab() {
+    let mock_string: String = "data-mapper-string-that-is-really-really-long".to_string();
+    let asserted_bool: bool = is_foreign_key(mock_string);
+    assert!(asserted_bool == false);
+}
+
+#[test] #[allow(non_snake_case)]
+fn returns_falsey_value_for_is_foreign_key_when_class() {
+    let mock_string: String = "DataMapperIsAReallyReallyLongString".to_string();
+    let asserted_bool: bool = is_foreign_key(mock_string);
+    assert!(asserted_bool == false);
+}
+
+#[test] #[allow(non_snake_case)]
+fn returns_falsey_value_for_is_foreign_key_when_title() {
+    let mock_string: String = "Data Mapper Is A Really Really Long String".to_string();
+    let asserted_bool: bool = is_foreign_key(mock_string);
+    assert!(asserted_bool == false);
+}
+
+#[test] #[allow(non_snake_case)]
+fn returns_falsey_value_for_is_foreign_key_when_camel() {
+    let mock_string: String = "dataMapperIsAReallyReallyLongString".to_string();
+    let asserted_bool: bool = is_foreign_key(mock_string);
+    assert!(asserted_bool == false);
+}
+
+#[test] #[allow(non_snake_case)]
+fn returns_falsey_value_for_is_foreign_key_when_snake() {
+    let mock_string: String = "data_mapper_string_that_is_really_really_long".to_string();
+    let asserted_bool: bool = is_foreign_key(mock_string);
+    assert!(asserted_bool == false);
+}
+
+#[test] #[allow(non_snake_case)]
+fn returns_truthy_value_for_is_foreign_key_when_foreign_key() {
+    let mock_string: String = "data_mapper_string_that_is_really_really_long_id".to_string();
+    let asserted_bool: bool = is_foreign_key(mock_string);
+    assert!(asserted_bool == true);
+}
+
+#[test] #[allow(non_snake_case)]
+fn foreign_key_data_mapper_as_data_mapper() {
+    let mock_string: String = "data_mapper".to_string();
+    let expected_string: String = "data_mapper_id".to_string();
+    let asserted_string: String = to_foreign_key(mock_string);
+    assert!(asserted_string == expected_string);
+}
+
+#[test] #[allow(non_snake_case)]
+fn foreign_key_Data_space_mapper_as_data_mapper() {
+    let mock_string: String = "Data mapper".to_string();
+    let expected_string: String = "data_mapper_id".to_string();
+    let asserted_string: String = to_foreign_key(mock_string);
+    assert!(asserted_string == expected_string);
+}
+
+#[test] #[allow(non_snake_case)]
+fn foreign_key_Data_space_Mapper_as_data_mapper() {
+    let mock_string: String = "Data Mapper".to_string();
+    let expected_string: String = "data_mapper_id".to_string();
+    let asserted_string: String = to_foreign_key(mock_string);
+    assert!(asserted_string == expected_string);
+}
+
+#[test] #[allow(non_snake_case)]
+fn foreign_key_Data_namespace_Mapper_as_data_mapper() {
+    let mock_string: String = "Data::Mapper".to_string();
+    let expected_string: String = "mapper_id".to_string();
+    let asserted_string: String = to_foreign_key(mock_string);
+    assert!(asserted_string == expected_string);
+}
+
+#[test] #[allow(non_snake_case)]
+fn foreign_key_Test_namespace_Data_namespace_Mapper_as_data_mapper() {
+    let mock_string: String = "Test::Data::Mapper".to_string();
+    let expected_string: String = "mapper_id".to_string();
+    let asserted_string: String = to_foreign_key(mock_string);
+    assert!(asserted_string == expected_string);
+}
+
+#[test] #[allow(non_snake_case)]
+fn foreign_key_DataMapper_as_data_mapper() {
+    let mock_string: String = "DataMapper".to_string();
+    let expected_string: String = "data_mapper_id".to_string();
+    let asserted_string: String = to_foreign_key(mock_string);
+    assert!(asserted_string == expected_string);
+}
+
+#[test] #[allow(non_snake_case)]
+fn foreign_key_dataMapper_as_data_mapper() {
+    let mock_string: String = "dataMapper".to_string();
+    let expected_string: String = "data_mapper_id".to_string();
+    let asserted_string: String = to_foreign_key(mock_string);
+    assert!(asserted_string == expected_string);
+}
+
+#[test] #[allow(non_snake_case)]
+fn foreign_key_dataMapper3_as_data_mapper() {
+    let mock_string: String = "dataMapper3".to_string();
+    let expected_string: String = "data_mapper_3_id".to_string();
+    let asserted_string: String = to_foreign_key(mock_string);
+    assert!(asserted_string == expected_string);
+}

--- a/src/suffix/foreignkey/mod.rs
+++ b/src/suffix/foreignkey/mod.rs
@@ -1,0 +1,37 @@
+use regex::Regex;
+
+use cases::snakecase::to_snake_case;
+
+pub fn to_foreign_key<'a>(non_foreign_key_string: String) -> String {
+    if is_foreign_key(non_foreign_key_string.clone()){
+        return non_foreign_key_string;
+    } else {
+        if non_foreign_key_string.contains("::") {
+            let split_string: Vec<&str> = non_foreign_key_string.split("::").collect();
+            return safe_convert(split_string[split_string.len() - 1].to_string());
+
+        } else {
+            return safe_convert(non_foreign_key_string);
+        }
+    }
+}
+    fn safe_convert<'a>(safe_string: String) -> String{
+        let snake_cased: String = to_snake_case(safe_string);
+        return format!("{}{}", snake_cased, "_id");
+    }
+
+pub fn is_foreign_key<'a>(test_string: String) -> bool{
+    let foreign_key_matcher= Regex::new(r"(?:[^-|^ ]?=^|[_])([a-z]+)").unwrap();
+    let upcase_matcher = Regex::new(r"[A-Z]").unwrap();
+    let mut is_foreign_key: bool = false;
+    if foreign_key_matcher.is_match(test_string.as_ref())
+        && !upcase_matcher.is_match(test_string.as_ref())
+        && test_string.ends_with("_id"){
+            is_foreign_key= true;
+        }
+    return is_foreign_key;
+}
+
+
+#[cfg(test)]
+mod foreignkey_test;

--- a/src/suffix/mod.rs
+++ b/src/suffix/mod.rs
@@ -1,0 +1,1 @@
+pub mod foreignkey;


### PR DESCRIPTION
# What it does:
- Adds support for foreign key
- Adds demodulize
- Adds deconstantize
- Adds traits for each mentioned
- Updates readme

# Why?
- Foreign key support is expected as an option in most common inflection libraries.
- Deconstantize and demodulize were easy additions with very little complexity.