### PR TITLE
Performance Fixes by removing reliance on regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Inflector"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Josh Teeter<joshteeter@gmail.com>"]
 exclude = [".travis.yml", ".gitignore"]
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ acting on String types.
 ### As a [crate](http://crates.io)
 ```toml
 [dependencies]
-Inflector = "0.1.2"
+Inflector = "0.1.4"
 ```
 
 ### Compile yourself:

--- a/src/cases/camelcase/camelcase_test.rs
+++ b/src/cases/camelcase/camelcase_test.rs
@@ -57,6 +57,13 @@ fn camelize_DataMapper3_as_dataMapper3() {
 }
 
 #[test] #[allow(non_snake_case)]
+fn returns_falsey_value_for_is_camel_case_when_lower_case() {
+    let mock_string: String = "data".to_string();
+    let asserted_bool: bool = is_camel_case(mock_string);
+    assert!(asserted_bool == false);
+}
+
+#[test] #[allow(non_snake_case)]
 fn returns_falsey_value_for_is_camel_case_when_kebab() {
     let mock_string: String = "data-mapper-string-that-is-really-really-long".to_string();
     let asserted_bool: bool = is_camel_case(mock_string);

--- a/src/cases/camelcase/camelcase_test.rs
+++ b/src/cases/camelcase/camelcase_test.rs
@@ -57,6 +57,13 @@ fn camelize_DataMapper3_as_dataMapper3() {
 }
 
 #[test] #[allow(non_snake_case)]
+fn returns_falsey_value_for_is_camel_case_when_start_cased() {
+    let mock_string: String = "Data".to_string();
+    let asserted_bool: bool = is_camel_case(mock_string);
+    assert!(asserted_bool == false);
+}
+
+#[test] #[allow(non_snake_case)]
 fn returns_falsey_value_for_is_camel_case_when_lower_case() {
     let mock_string: String = "data".to_string();
     let asserted_bool: bool = is_camel_case(mock_string);

--- a/src/cases/camelcase/mod.rs
+++ b/src/cases/camelcase/mod.rs
@@ -16,19 +16,21 @@ pub fn to_camel_case<'a>(non_camelized_string: String) -> String {
         let mut split_string: Vec<&str> = non_camelized_string.split("_").collect();
         let mut out_string: String = split_string.remove(0).to_string();
         for string in split_string {
-            if string != "" {
+            if string != "" && !is_camel_case(string.to_string()) {
                 let mut string_chars: Vec<char> = string.chars().collect();
                 let first_char: &str = &to_upper_case(string_chars.iter().nth(0).unwrap().to_string());
                 string_chars.remove(0);
                 let end_of_word: &str = &string_chars.iter().cloned().collect::<String>();
                 out_string = out_string + first_char + end_of_word;
+            } else {
+                out_string = out_string + string;
             }
         }
         return out_string;
     }
 
 pub fn is_camel_case<'a>(test_string: String) -> bool{
-    let camel_matcher = Regex::new(r"(^|[A-Z])([^-|^_|^ ]*[a-z]+)").unwrap();
+    let camel_matcher = Regex::new(r"(^|[A-Z])([^-|^_|^ ]*[a-z0-9]+[A-Z][a-z0-9]+)").unwrap();
     let kebab_snake_matcher = Regex::new(r"[-|_| ]").unwrap();
     if camel_matcher.is_match(test_string.as_ref())
         && !kebab_snake_matcher.is_match(test_string.as_ref())

--- a/src/cases/camelcase/mod.rs
+++ b/src/cases/camelcase/mod.rs
@@ -5,11 +5,7 @@ use cases::snakecase::to_snake_case;
 use cases::uppercase::to_upper_case;
 
 pub fn to_camel_case<'a>(non_camelized_string: String) -> String {
-    if is_camel_case(non_camelized_string.clone()) {
-        return non_camelized_string
-    } else {
-        return to_camel_from_snake(to_snake_case(non_camelized_string));
-    }
+    return to_camel_from_snake(to_snake_case(non_camelized_string));
 }
 
     fn to_camel_from_snake<'a>(non_camelized_string: String) -> String{

--- a/src/cases/camelcase/mod.rs
+++ b/src/cases/camelcase/mod.rs
@@ -1,26 +1,28 @@
+use std::ascii::*;
 use regex::Regex;
 
 use cases::classcase::is_class_case;
 use cases::snakecase::to_snake_case;
-use cases::uppercase::to_upper_case;
 
 pub fn to_camel_case<'a>(non_camelized_string: String) -> String {
     return to_camel_from_snake(to_snake_case(non_camelized_string));
 }
 
     fn to_camel_from_snake<'a>(non_camelized_string: String) -> String{
-        let mut split_string: Vec<&str> = non_camelized_string.split("_").collect();
-        let mut out_string: String = split_string.remove(0).to_string();
-        for string in split_string {
-            if string != "" {
-                let mut string_chars: Vec<char> = string.chars().collect();
-                let first_char: &str = &to_upper_case(string_chars.iter().nth(0).unwrap().to_string());
-                string_chars.remove(0);
-                let end_of_word: &str = &string_chars.iter().cloned().collect::<String>();
-                out_string = out_string + first_char + end_of_word;
+        let mut result:String = "".to_string();
+        let mut new_word: bool = false;
+
+        for character in non_camelized_string.chars() {
+            if character.to_string() == "_" {
+                new_word = true;
+            } else if new_word {
+                result = format!("{}{}", result, character.to_ascii_uppercase());
+                new_word = false;
+            } else {
+                result = format!("{}{}", result, character.to_ascii_lowercase());
             }
         }
-        return out_string;
+        return result
     }
 
 pub fn is_camel_case<'a>(test_string: String) -> bool{

--- a/src/cases/camelcase/mod.rs
+++ b/src/cases/camelcase/mod.rs
@@ -16,14 +16,12 @@ pub fn to_camel_case<'a>(non_camelized_string: String) -> String {
         let mut split_string: Vec<&str> = non_camelized_string.split("_").collect();
         let mut out_string: String = split_string.remove(0).to_string();
         for string in split_string {
-            if string != "" && !is_camel_case(string.to_string()) {
+            if string != "" {
                 let mut string_chars: Vec<char> = string.chars().collect();
                 let first_char: &str = &to_upper_case(string_chars.iter().nth(0).unwrap().to_string());
                 string_chars.remove(0);
                 let end_of_word: &str = &string_chars.iter().cloned().collect::<String>();
                 out_string = out_string + first_char + end_of_word;
-            } else {
-                out_string = out_string + string;
             }
         }
         return out_string;

--- a/src/cases/classcase/classcase_test.rs
+++ b/src/cases/classcase/classcase_test.rs
@@ -48,6 +48,20 @@ fn ClassCase_Data_space_mapper_as_DataMapper() {
 }
 
 #[test] #[allow(non_snake_case)]
+fn returns_truthy_value_for_is_class_case_when_start_cased() {
+    let mock_string: String = "Data".to_string();
+    let asserted_bool: bool = is_class_case(mock_string);
+    assert!(asserted_bool == true);
+}
+
+#[test] #[allow(non_snake_case)]
+fn returns_falsey_value_for_is_class_case_when_downcased() {
+    let mock_string: String = "data".to_string();
+    let asserted_bool: bool = is_class_case(mock_string);
+    assert!(asserted_bool == false);
+}
+
+#[test] #[allow(non_snake_case)]
 fn returns_truthy_value_for_is_class_case_when_class() {
     let mock_string: String = "DataMapperIsAReallyReallyLongString".to_string();
     let asserted_bool: bool = is_class_case(mock_string);

--- a/src/cases/classcase/mod.rs
+++ b/src/cases/classcase/mod.rs
@@ -1,28 +1,26 @@
+use std::ascii::*;
 use regex::Regex;
 
 use cases::snakecase::to_snake_case;
-use cases::uppercase::to_upper_case;
 
 pub fn to_class_case<'a>(non_class_case_string: String) -> String {
-    if is_class_case(non_class_case_string.clone()){
-        return non_class_case_string
-    } else {
-        return to_class_from_snake(to_snake_case(non_class_case_string));
-    }
+    return to_class_from_snake(to_snake_case(non_class_case_string));
 }
-    fn to_class_from_snake<'a>(non_class_case_string: String) -> String{
-        let split_string: Vec<&str> = non_class_case_string.split("_").collect();
-        let mut out_string: String = "".to_string();
-        for string in split_string {
-            if string != "" {
-                let mut string_chars: Vec<char> = string.chars().collect();
-                let first_char: &str = &to_upper_case(string_chars.iter().nth(0).unwrap().to_string());
-                string_chars.remove(0);
-                let end_of_word: &str = &string_chars.iter().cloned().collect::<String>();
-                out_string = out_string + first_char + end_of_word;
+    fn to_class_from_snake<'a>(non_class_case_string: String) -> String {
+        let mut result:String = "".to_string();
+        let mut new_word: bool = true;
+
+        for character in non_class_case_string.chars() {
+            if character.to_string() == "_" {
+                new_word = true;
+            } else if new_word {
+                result = format!("{}{}", result, character.to_ascii_uppercase());
+                new_word = false;
+            } else {
+                result = format!("{}{}", result, character.to_ascii_lowercase());
             }
         }
-        return out_string;
+        return result
     }
 
 pub fn is_class_case<'a>(test_string: String) -> bool{

--- a/src/cases/classcase/mod.rs
+++ b/src/cases/classcase/mod.rs
@@ -24,7 +24,7 @@ pub fn to_class_case<'a>(non_class_case_string: String) -> String {
     }
 
 pub fn is_class_case<'a>(test_string: String) -> bool{
-    let class_matcher = Regex::new(r"(^[A-Z])([^-|^_|^ ]*[a-z]+)").unwrap();
+    let class_matcher = Regex::new(r"(^[A-Z])([^-|^_|^ ]*[a-z0-9]+)").unwrap();
     let space_matcher = Regex::new(r" +").unwrap();
     if class_matcher.is_match(test_string.as_ref()) && !space_matcher.is_match(test_string.as_ref()){
         return true;

--- a/src/cases/kebabcase/mod.rs
+++ b/src/cases/kebabcase/mod.rs
@@ -1,7 +1,6 @@
 use regex::Regex;
 
 use cases::snakecase::to_snake_case;
-use cases::lowercase::to_lower_case;
 
 pub fn is_kebab_case<'a>(test_string: String) -> bool{
     let kebab_matcher = Regex::new(r"(?:[^_]?=^|[-])([a-z]+)").unwrap();
@@ -11,11 +10,10 @@ pub fn is_kebab_case<'a>(test_string: String) -> bool{
 }
 
 pub fn to_kebab_case<'a>(non_kebab_case_string: String) -> String {
-    let snake_case_string = to_snake_case(non_kebab_case_string);
-    return to_kebab_from_snake(snake_case_string);
+    return to_kebab_from_snake(to_snake_case(non_kebab_case_string));
 }
     fn to_kebab_from_snake<'a>(non_kebab_case_string: String) -> String {
-        return to_lower_case(non_kebab_case_string.replace("_", "-"));
+        return non_kebab_case_string.replace("_", "-");
     }
 
 #[cfg(test)]

--- a/src/cases/lowercase/lower_test.rs
+++ b/src/cases/lowercase/lower_test.rs
@@ -14,6 +14,12 @@ fn returns_truthy_value_for_is_lower_case_when_lowercase() {
     let asserted_bool: bool = is_lower_case(mock_string);
     assert!(asserted_bool == true);
 }
+#[test] #[allow(non_snake_case)]
+fn returns_falsey_value_for_is_lower_case_when_Startcased() {
+    let mock_string: String = "Datamapperisareallyreallylongstring".to_string();
+    let asserted_bool: bool = is_lower_case(mock_string);
+    assert!(asserted_bool == false);
+}
 
 #[test] #[allow(non_snake_case)]
 fn returns_falsey_value_for_is_lower_case_when_uppercase() {

--- a/src/cases/sentencecase/mod.rs
+++ b/src/cases/sentencecase/mod.rs
@@ -24,7 +24,7 @@ pub fn to_sentence_case<'a>(non_sentence_case_string: String) -> String {
     }
 
 pub fn is_sentence_case<'a>(test_string: String) -> bool{
-    let sentence_matcher= Regex::new(r"(^[A-Z])([^-|^_]*[ ][^A-Z][a-z]+)").unwrap();
+    let sentence_matcher= Regex::new(r"(^[A-Z])([^-|^_]*[ ][^A-Z][a-z0-9]+)").unwrap();
     let mut is_sentence_case= false;
     if sentence_matcher.is_match(test_string.as_ref())
         && !is_class_case(test_string.clone()){

--- a/src/cases/sentencecase/mod.rs
+++ b/src/cases/sentencecase/mod.rs
@@ -1,33 +1,26 @@
+use std::ascii::*;
 use regex::Regex;
 
 use cases::classcase::is_class_case;
 use cases::snakecase::to_snake_case;
-use cases::uppercase::to_upper_case;
 
 pub fn to_sentence_case<'a>(non_sentence_case_string: String) -> String {
-    if is_sentence_case(non_sentence_case_string.clone()) {
-        return non_sentence_case_string
-    } else {
-        return to_sentence_from_snake_or_kebab(to_snake_case(non_sentence_case_string));
-    }
+    return to_sentence_from_snake(to_snake_case(non_sentence_case_string));
 }
-    fn to_sentence_from_snake_or_kebab<'a>(non_sentence_case_string: String) -> String{
-        let mut split_string: Vec<&str> = non_sentence_case_string.split("_").collect();
-        let first_word: &str = split_string.remove(0);
-        let mut string_chars: Vec<char> = first_word.chars().collect();
-        let mut out_string: String = "".to_string();
-
-        if first_word != "" {
-            let first_char: &str = &to_upper_case(string_chars.iter().nth(0).unwrap().to_string());
-            string_chars.remove(0);
-            let end_of_word: &str = &string_chars.iter().cloned().collect::<String>();
-            out_string =  first_char.to_string() + end_of_word;
+    fn to_sentence_from_snake<'a>(non_sentence_case_string: String) -> String {
+        let mut result:String = "".to_string();
+        let mut first_character: bool = true;
+        for character in non_sentence_case_string.chars() {
+            if character.to_string() != "_" && character.to_string() != "-" && !first_character {
+                result = format!("{}{}", result, character.to_ascii_lowercase());
+            } else if character.to_string() == "_" || character.to_string() == "-" {
+                result = format!("{} ", result);
+            } else {
+                result = format!("{}{}", result, character.to_ascii_uppercase());
+                first_character = false;
+            }
         }
-
-        for string in split_string {
-            out_string = out_string + " " +  string;
-        }
-        return out_string;
+        return result
     }
 
 pub fn is_sentence_case<'a>(test_string: String) -> bool{

--- a/src/cases/sentencecase/sentencecase_test.rs
+++ b/src/cases/sentencecase/sentencecase_test.rs
@@ -36,6 +36,20 @@ fn returns_falsey_value_for_is_sentence_case_when_snake() {
 }
 
 #[test] #[allow(non_snake_case)]
+fn returns_truthy_value_for_is_sentence_case_when_start_cased() {
+    let mock_string: String = "Data".to_string();
+    let asserted_bool: bool = is_sentence_case(mock_string);
+    assert!(asserted_bool == false);
+}
+
+#[test] #[allow(non_snake_case)]
+fn returns_falsey_value_for_is_sentence_case_when_lower() {
+    let mock_string: String = "data".to_string();
+    let asserted_bool: bool = is_sentence_case(mock_string);
+    assert!(asserted_bool == false);
+}
+
+#[test] #[allow(non_snake_case)]
 fn returns_truthy_value_for_is_sentence_case_when_sentence() {
     let mock_string: String = "Data mapper string that is really really long".to_string();
     let asserted_bool: bool = is_sentence_case(mock_string);

--- a/src/cases/snakecase/mod.rs
+++ b/src/cases/snakecase/mod.rs
@@ -1,21 +1,18 @@
 use regex::Regex;
 
-use cases::classcase::is_class_case;
-use cases::camelcase::is_camel_case;
 use cases::lowercase::to_lower_case;
 
 pub fn to_snake_case<'a>(non_snake_case_string: String) -> String {
     if is_snake_case(non_snake_case_string.clone()) {
         return non_snake_case_string;
-    } else if is_camel_case(non_snake_case_string.clone())
-        || is_class_case(non_snake_case_string.clone()) {
-        return to_snake_from_camel_or_class(non_snake_case_string);
-    } else {
+    } else if non_snake_case_string.contains(" ") || non_snake_case_string.contains("-") {
         return to_snake_from_sentence_or_kebab(non_snake_case_string);
+    } else {
+        return to_snake_from_camel_or_class(non_snake_case_string);
     }
 }
     fn to_snake_from_camel_or_class <'a>(non_snake_case_string: String) -> String {
-        let re = Regex::new(r"(?P<a>[A-Z1-9])").unwrap();
+        let re = Regex::new(r"(?P<a>[A-Z0-9])").unwrap();
         let result: String = re.replace_all(&non_snake_case_string, "_$a$b").to_string();
         return to_lower_case(result.trim_left_matches("_").to_string());
     }

--- a/src/cases/snakecase/mod.rs
+++ b/src/cases/snakecase/mod.rs
@@ -5,14 +5,17 @@ use cases::camelcase::is_camel_case;
 use cases::lowercase::to_lower_case;
 
 pub fn to_snake_case<'a>(non_snake_case_string: String) -> String {
-    if is_camel_case(non_snake_case_string.clone()) || is_class_case(non_snake_case_string.clone()) {
+    if is_snake_case(non_snake_case_string.clone()) {
+        return non_snake_case_string;
+    } else if is_camel_case(non_snake_case_string.clone())
+        || is_class_case(non_snake_case_string.clone()) {
         return to_snake_from_camel_or_class(non_snake_case_string);
     } else {
         return to_snake_from_sentence_or_kebab(non_snake_case_string);
     }
 }
     fn to_snake_from_camel_or_class <'a>(non_snake_case_string: String) -> String {
-        let re = Regex::new(r"(?P<a>[A-Z0-9])").unwrap();
+        let re = Regex::new(r"(?P<a>[A-Z1-9])").unwrap();
         let result: String = re.replace_all(&non_snake_case_string, "_$a$b").to_string();
         return to_lower_case(result.trim_left_matches("_").to_string());
     }

--- a/src/cases/snakecase/mod.rs
+++ b/src/cases/snakecase/mod.rs
@@ -25,11 +25,6 @@ pub fn to_snake_case<'a>(non_snake_case_string: String) -> String {
         }
         return result
     }
-    // fn to_snake_from_camel_or_class <'a>(non_snake_case_string: String) -> String {
-    //     let re = Regex::new(r"(?P<a>[A-Z0-9])").unwrap();
-    //     let result: String = re.replace_all(&non_snake_case_string, "_$a$b").to_string();
-    //     return to_lower_case(result.trim_left_matches("_").to_string());
-    // }
 
     fn to_snake_from_sentence_or_kebab<'a>(non_snake_case_string: String) -> String {
         return to_lower_case(non_snake_case_string.replace(" ", "_").replace("-", "_"));

--- a/src/cases/snakecase/mod.rs
+++ b/src/cases/snakecase/mod.rs
@@ -1,3 +1,4 @@
+use std::ascii::*;
 use regex::Regex;
 
 use cases::lowercase::to_lower_case;
@@ -12,10 +13,23 @@ pub fn to_snake_case<'a>(non_snake_case_string: String) -> String {
     }
 }
     fn to_snake_from_camel_or_class <'a>(non_snake_case_string: String) -> String {
-        let re = Regex::new(r"(?P<a>[A-Z0-9])").unwrap();
-        let result: String = re.replace_all(&non_snake_case_string, "_$a$b").to_string();
-        return to_lower_case(result.trim_left_matches("_").to_string());
+        let mut result:String = "".to_string();
+        let mut first_character: bool = true;
+        for character in non_snake_case_string.chars() {
+            if character == character.to_ascii_uppercase() && !first_character {
+                result = format!("{}_{}", result, character.to_ascii_lowercase());
+            } else {
+                result = format!("{}{}", result, character.to_ascii_lowercase());
+                first_character = false;
+            }
+        }
+        return result
     }
+    // fn to_snake_from_camel_or_class <'a>(non_snake_case_string: String) -> String {
+    //     let re = Regex::new(r"(?P<a>[A-Z0-9])").unwrap();
+    //     let result: String = re.replace_all(&non_snake_case_string, "_$a$b").to_string();
+    //     return to_lower_case(result.trim_left_matches("_").to_string());
+    // }
 
     fn to_snake_from_sentence_or_kebab<'a>(non_snake_case_string: String) -> String {
         return to_lower_case(non_snake_case_string.replace(" ", "_").replace("-", "_"));

--- a/src/cases/snakecase/mod.rs
+++ b/src/cases/snakecase/mod.rs
@@ -3,9 +3,9 @@ use regex::Regex;
 use cases::lowercase::to_lower_case;
 
 pub fn to_snake_case<'a>(non_snake_case_string: String) -> String {
-    if is_snake_case(non_snake_case_string.clone()) {
-        return non_snake_case_string;
-    } else if non_snake_case_string.contains(" ") || non_snake_case_string.contains("-") {
+    if non_snake_case_string.contains(" ")
+        || non_snake_case_string.contains("_")
+        || non_snake_case_string.contains("-") {
         return to_snake_from_sentence_or_kebab(non_snake_case_string);
     } else {
         return to_snake_from_camel_or_class(non_snake_case_string);

--- a/src/cases/snakecase/snakecase_test.rs
+++ b/src/cases/snakecase/snakecase_test.rs
@@ -65,6 +65,14 @@ fn snake_case_data_mapper_as_data_mapper() {
 }
 
 #[test] #[allow(non_snake_case)]
+fn snake_case_HTTP_Data_space_mapper_as_data_mapper() {
+    let mock_string: String = "HTTP Data mapper".to_string();
+    let expected_string: String = "http_data_mapper".to_string();
+    let asserted_string: String = to_snake_case(mock_string);
+    assert!(asserted_string == expected_string);
+}
+
+#[test] #[allow(non_snake_case)]
 fn snake_case_Data_space_mapper_as_data_mapper() {
     let mock_string: String = "Data mapper".to_string();
     let expected_string: String = "data_mapper".to_string();

--- a/src/cases/titlecase/mod.rs
+++ b/src/cases/titlecase/mod.rs
@@ -1,28 +1,27 @@
+use std::ascii::*;
 use regex::Regex;
 
 use cases::snakecase::to_snake_case;
-use cases::uppercase::to_upper_case;
 
 pub fn to_title_case<'a>(non_title_case_string: String) -> String {
-    if is_title_case(non_title_case_string.clone()) {
-        return non_title_case_string
-    } else {
-        return to_title_from_snake(to_snake_case(non_title_case_string));
-    }
+    return to_title_from_snake(to_snake_case(non_title_case_string));
 }
-    fn to_title_from_snake<'a>(non_camelized_string: String) -> String{
-        let split_string: Vec<&str> = non_camelized_string.split("_").collect();
-        let mut out_string: String = "".to_string();
-        for string in split_string {
-            if string != "" {
-                let mut string_chars: Vec<char> = string.chars().collect();
-                let first_char: &str = &to_upper_case(string_chars.iter().nth(0).unwrap().to_string());
-                string_chars.remove(0);
-                let end_of_word: &str = &string_chars.iter().cloned().collect::<String>();
-                out_string = out_string + " " + first_char + end_of_word;
+
+    fn to_title_from_snake<'a>(non_sentence_case_string: String) -> String {
+        let mut result:String = "".to_string();
+        let mut first_character: bool = true;
+        for character in non_sentence_case_string.chars() {
+            if character.to_string() != "_" && character.to_string() != "-" && !first_character {
+                result = format!("{}{}", result, character.to_ascii_lowercase());
+                first_character = false
+            } else if character.to_string() == "_" || character.to_string() == "-" {
+                first_character = true;
+            } else {
+                result = format!("{} {}", result, character.to_ascii_uppercase());
+                first_character = false;
             }
         }
-        return out_string.trim().to_string();
+        return result.trim().to_string();
     }
 
 pub fn is_title_case<'a>(test_string: String) -> bool{

--- a/src/cases/titlecase/mod.rs
+++ b/src/cases/titlecase/mod.rs
@@ -25,7 +25,7 @@ pub fn to_title_case<'a>(non_title_case_string: String) -> String {
     }
 
 pub fn is_title_case<'a>(test_string: String) -> bool{
-    let title_matcher= Regex::new(r"(^[A-Z][a-z]+)([^-|^_]*[ ][A-Z][a-z]+)").unwrap();
+    let title_matcher= Regex::new(r"(^[A-Z][a-z0-9]+)([^-|^_]*[ ][A-Z][a-z0-9]+)").unwrap();
     let mut is_title_case= false;
     if title_matcher.is_match(test_string.as_ref()) {
         is_title_case = true;

--- a/src/cases/titlecase/titlecase_test.rs
+++ b/src/cases/titlecase/titlecase_test.rs
@@ -36,6 +36,13 @@ fn returns_falsey_value_for_is_title_case_when_sentence() {
 }
 
 #[test] #[allow(non_snake_case)]
+fn returns_falsey_value_for_is_title_case_when_lower() {
+    let mock_string: String = "data".to_string();
+    let asserted_bool: bool = is_title_case(mock_string);
+    assert!(asserted_bool == false);
+}
+
+#[test] #[allow(non_snake_case)]
 fn returns_truthy_value_for_is_title_case_when_title() {
     let mock_string: String = "Data Mapper String That Is Really Really Long".to_string();
     let asserted_bool: bool = is_title_case(mock_string);


### PR DESCRIPTION
# What it does:
- Fixes performance issues seen in #12.
- Reverts some algorithmic changes seen in #11 

# What was learned:
- Regex checks are very costly. It's actually faster to just assume the string is incorrect and fix it than check. 
- Regex replace_all is also very slow currently.

# Why it does it:
Performance on my test project:

| Crate  | Time in S to convert large SVG to camelCase  |
|---|---|
|  case | 1.933  |
| inflector **This branch** | 2.274  |
| inflector **0.1.3** | 8.111  |
| inflector **0.1.2**  |  10.296  |