### PR TITLE
Replaced custom implementation of lower and upper cases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ rust:
   - 1.5.0
   - 1.4.0
   - 1.3.0
-  - 1.2.0
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ rust:
   - stable
   - beta
   - nightly
+  - 1.9.0
+  - 1.8.0
+  - 1.7.0
+  - 1.6.0
   - 1.5.0
   - 1.4.0
   - 1.3.0
   - 1.2.0
-  - 1.1.0
-  - 1.0.0
 
 matrix:
   allow_failures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ path = "src/lib.rs"
 
 [dependencies]
 regex = "0.1.41"
+clippy = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,7 @@ path = "src/lib.rs"
 
 [dependencies]
 regex = "0.1.41"
-clippy = "*"
+clippy = {version = "*", optional = true}
+
+[features]
+default=[]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Inflector"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Josh Teeter<joshteeter@gmail.com>"]
 exclude = [".travis.yml", ".gitignore"]
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rust Inflector
 
 
-[![Build Status](https://travis-ci.org/whatisinternet/inflector.svg?branch=master)](https://travis-ci.org/whatisinternet/inflector) [![Crates.io](https://img.shields.io/crates/v/inflector.svg)](https://crates.io/crates/inflector)
+[![Build Status](https://travis-ci.org/whatisinternet/inflector.svg?branch=master?style=flat-square)](https://travis-ci.org/whatisinternet/inflector) [![Crates.io](https://img.shields.io/crates/v/inflector.svg?stype=flat-square)](https://crates.io/crates/inflector)[![Clippy Linting Result](https://clippy.bashy.io/github/whatisinternet/inflector/master/badge.svg?style=flat-square)](https://clippy.bashy.io/github/whatisinternet/inflector/master/log)
 
 Adds String based inflections for Rust. Snake, kebab, camel,
 sentence, class, title, upper, and lower cases as well as ordinalize,

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+# 0.2.1
+
+## Features:
+
+- Replaced custom implementation of lower and uppercase with Rust default
+
+## Breaking changes:
+
+- Rust 1.2 or greater required
+
 # 0.2.0
 
 ## Features:

--- a/src/cases/camelcase/mod.rs
+++ b/src/cases/camelcase/mod.rs
@@ -87,11 +87,11 @@ use cases::snakecase::to_snake_case;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_camel_case<'a>(non_camelized_string: String) -> String {
-    return to_camel_from_snake(to_snake_case(non_camelized_string));
+pub fn to_camel_case(non_camelized_string: String) -> String {
+    to_camel_from_snake(to_snake_case(non_camelized_string))
 }
 
-    fn to_camel_from_snake<'a>(non_camelized_string: String) -> String{
+    fn to_camel_from_snake(non_camelized_string: String) -> String{
         let mut result:String = "".to_string();
         let mut new_word: bool = false;
 
@@ -105,7 +105,7 @@ pub fn to_camel_case<'a>(non_camelized_string: String) -> String {
                 result = format!("{}{}", result, character.to_ascii_lowercase());
             }
         }
-        return result
+        result
     }
 
 /// Determines if a `String` is camelCase bool``
@@ -210,7 +210,7 @@ pub fn to_camel_case<'a>(non_camelized_string: String) -> String {
 ///     let asserted_bool: bool = is_camel_case(mock_string);
 ///     assert!(asserted_bool == false);
 /// ```
-pub fn is_camel_case<'a>(test_string: String) -> bool{
+pub fn is_camel_case(test_string: String) -> bool{
     let camel_matcher = Regex::new(r"(^|[A-Z])([^-|^_|^ ]*[a-z0-9]+[A-Z][a-z0-9]+)").unwrap();
     let kebab_snake_matcher = Regex::new(r"[-|_| ]").unwrap();
     if camel_matcher.is_match(test_string.as_ref())
@@ -218,5 +218,5 @@ pub fn is_camel_case<'a>(test_string: String) -> bool{
         && !is_class_case(test_string){
             return true;
         }
-    return false;
+    false
 }

--- a/src/cases/classcase/mod.rs
+++ b/src/cases/classcase/mod.rs
@@ -4,7 +4,7 @@ use regex::Regex;
 use cases::snakecase::to_snake_case;
 use string::singularize::to_singular;
 
-/// Converts a `String` to ClassCase `String`
+/// Converts a `String` to `ClassCase` `String`
 ///
 /// #Examples
 /// ```
@@ -104,10 +104,10 @@ use string::singularize::to_singular;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_class_case<'a>(non_class_case_string: String) -> String {
-    return to_class_from_snake(to_snake_case(non_class_case_string));
+pub fn to_class_case(non_class_case_string: String) -> String {
+    to_class_from_snake(to_snake_case(non_class_case_string))
 }
-    fn to_class_from_snake<'a>(non_class_case_string: String) -> String {
+    fn to_class_from_snake(non_class_case_string: String) -> String {
         let singularized_word: String = to_singular(non_class_case_string);
         let mut result:String = "".to_string();
         let mut new_word: bool = true;
@@ -122,10 +122,10 @@ pub fn to_class_case<'a>(non_class_case_string: String) -> String {
                 result = format!("{}{}", result, character.to_ascii_lowercase());
             }
         }
-        return result
+        result
     }
 
-/// Determines if a `String` is ClassCase `bool`
+/// Determines if a `String` is `ClassCase` `bool`
 ///
 /// #Examples
 /// ```
@@ -248,7 +248,7 @@ pub fn to_class_case<'a>(non_class_case_string: String) -> String {
 ///     assert!(asserted_bool == false);
 ///
 /// ```
-pub fn is_class_case<'a>(test_string: String) -> bool{
+pub fn is_class_case(test_string: String) -> bool{
     let class_matcher = Regex::new(r"(^[A-Z])([^-|^_|^ ]*[a-z0-9]+)").unwrap();
     let space_matcher = Regex::new(r" +").unwrap();
     let singularized_word: String = to_singular(test_string.clone());
@@ -257,5 +257,5 @@ pub fn is_class_case<'a>(test_string: String) -> bool{
         && singularized_word == test_string{
         return true;
     }
-    return false;
+    false
 }

--- a/src/cases/kebabcase/mod.rs
+++ b/src/cases/kebabcase/mod.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 
 use cases::snakecase::to_snake_case;
 
-/// Converts a `String` to kebab-case `String`
+/// Converts a `String` to `kebab-case` `String`
 ///
 /// #Examples
 /// ```
@@ -88,14 +88,14 @@ use cases::snakecase::to_snake_case;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn is_kebab_case<'a>(test_string: String) -> bool{
+pub fn is_kebab_case(test_string: String) -> bool{
     let kebab_matcher = Regex::new(r"(?:[^_]?=^|[-])([a-z]+)").unwrap();
     let upcase_matcher = Regex::new(r"[A-Z]").unwrap();
-    return kebab_matcher.is_match(test_string.as_ref())
+    kebab_matcher.is_match(test_string.as_ref())
         && !upcase_matcher.is_match(test_string.as_ref())
 }
 
-/// Determines if a `String` is kebab-case
+/// Determines if a `String` is `kebab-case`
 ///
 /// #Examples
 /// ```
@@ -174,9 +174,9 @@ pub fn is_kebab_case<'a>(test_string: String) -> bool{
 ///     assert!(asserted_bool == false);
 ///
 /// ```
-pub fn to_kebab_case<'a>(non_kebab_case_string: String) -> String {
-    return to_kebab_from_snake(to_snake_case(non_kebab_case_string));
+pub fn to_kebab_case(non_kebab_case_string: String) -> String {
+    to_kebab_from_snake(to_snake_case(non_kebab_case_string))
 }
-    fn to_kebab_from_snake<'a>(non_kebab_case_string: String) -> String {
-        return non_kebab_case_string.replace("_", "-");
+    fn to_kebab_from_snake(non_kebab_case_string: String) -> String {
+        non_kebab_case_string.replace("_", "-")
     }

--- a/src/cases/lowercase/mod.rs
+++ b/src/cases/lowercase/mod.rs
@@ -12,7 +12,7 @@
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_lower_case<'a>(non_lower_string : String) -> String {
+pub fn to_lower_case(non_lower_string : String) -> String {
     // See https://github.com/calebmer/inflections/blob/master/src/case.rs#L37 for where this
     // implementation comes from.
     non_lower_string
@@ -54,6 +54,6 @@ pub fn to_lower_case<'a>(non_lower_string : String) -> String {
 ///     assert!(asserted_bool == false);
 ///
 /// ```
-pub fn is_lower_case<'a>(test_string: String) -> bool{
-    return test_string == to_lower_case(test_string.clone())
+pub fn is_lower_case(test_string: String) -> bool{
+    test_string == to_lower_case(test_string.clone())
 }

--- a/src/cases/lowercase/mod.rs
+++ b/src/cases/lowercase/mod.rs
@@ -1,6 +1,3 @@
-use std::ascii::*;
-use regex::Regex;
-
 /// Converts a `String` to lowercase `String`
 ///
 /// #Examples
@@ -15,12 +12,13 @@ use regex::Regex;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_lower_case<'a>(non_camelized_string: String) -> String {
-    let mut result:String = "".to_string();
-    for character in non_camelized_string.chars() {
-        result = format!("{}{}", result, character.to_ascii_lowercase());
-    }
-    return result
+pub fn to_lower_case<'a>(non_lower_string : String) -> String {
+    // See https://github.com/calebmer/inflections/blob/master/src/case.rs#L37 for where this
+    // implementation comes from.
+    non_lower_string
+        .chars()
+        .flat_map(char::to_lowercase)
+        .collect()
 }
 
 /// Determines if a `String` is lowercase
@@ -57,10 +55,5 @@ pub fn to_lower_case<'a>(non_camelized_string: String) -> String {
 ///
 /// ```
 pub fn is_lower_case<'a>(test_string: String) -> bool{
-    let lower_matcher = Regex::new(r"^[a-z| |_|-]+$").unwrap();
-    let mut is_lower_case = false;
-    if lower_matcher.is_match(test_string.as_ref()){
-        is_lower_case = true;
-    }
-    return is_lower_case;
+    return test_string == to_lower_case(test_string.clone())
 }

--- a/src/cases/mod.rs
+++ b/src/cases/mod.rs
@@ -1,49 +1,49 @@
 /// Provides conversion to and detection of class case strings.
 ///
-/// Example string "ClassCase"
+/// Example string `ClassCase`
 pub mod classcase;
 
 /// Provides conversion to and detection of camel case strings.
 ///
-/// Example string "camelCase"
+/// Example string `camelCase`
 pub mod camelcase;
 
 /// Provides conversion to and detection of snake case strings.
 ///
-/// Example string "snake_case"
+/// Example string `snake_case`
 pub mod snakecase;
 
 /// Provides conversion to and detection of screaming snake case strings.
 ///
-/// Example string "SCREAMING_SNAKE_CASE"
+/// Example string `SCREAMING_SNAKE_CASE`
 pub mod screamingsnakecase;
 
 /// Provides conversion to and detection of kebab case strings.
 ///
-/// Example string "kebab-case"
+/// Example string `kebab-case`
 pub mod kebabcase;
 
 /// Provides conversion to and detection of sentence case strings.
 ///
-/// Example string "Sentence case"
+/// Example string `Sentence case`
 pub mod sentencecase;
 
 /// Provides conversion to and detection of title case strings.
 ///
-/// Example string "Title Case"
+/// Example string `Title Case`
 pub mod titlecase;
 
 /// Provides conversion to and detection of table case strings.
 ///
-/// Example string "table_cases"
+/// Example string `table_cases`
 pub mod tablecase;
 
 /// Provides conversion to upper case strings.
 ///
-/// Example string "UPPERCASE"
+/// Example string `UPPERCASE`
 pub mod uppercase;
 
 /// Provides conversion to lower case strings.
 ///
-/// Example string "LOWERCASE"
+/// Example string `LOWERCASE`
 pub mod lowercase;

--- a/src/cases/screamingsnakecase/mod.rs
+++ b/src/cases/screamingsnakecase/mod.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 
 use cases::uppercase::to_upper_case;
 
-/// Converts a `String` to SCREAMING_SNAKE_CASE `String`
+/// Converts a `String` to `SCREAMING_SNAKE_CASE` `String`
 ///
 /// #Examples
 /// ```
@@ -83,16 +83,16 @@ use cases::uppercase::to_upper_case;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_screaming_snake_case<'a>(non_snake_case_string: String) -> String {
-    if non_snake_case_string.contains(" ")
-        || non_snake_case_string.contains("_")
-        || non_snake_case_string.contains("-") {
-        return to_snake_from_sentence_or_kebab(non_snake_case_string);
+pub fn to_screaming_snake_case(non_snake_case_string: String) -> String {
+    if non_snake_case_string.contains(' ')
+        || non_snake_case_string.contains('_')
+        || non_snake_case_string.contains('-') {
+        to_snake_from_sentence_or_kebab(non_snake_case_string)
     } else {
-        return to_snake_from_camel_or_class(non_snake_case_string);
+        to_snake_from_camel_or_class(non_snake_case_string)
     }
 }
-    fn to_snake_from_camel_or_class <'a>(non_snake_case_string: String) -> String {
+    fn to_snake_from_camel_or_class (non_snake_case_string: String) -> String {
         let mut result:String = "".to_string();
         let mut first_character: bool = true;
         for character in non_snake_case_string.chars() {
@@ -103,14 +103,14 @@ pub fn to_screaming_snake_case<'a>(non_snake_case_string: String) -> String {
                 first_character = false;
             }
         }
-        return result
+        result
     }
 
-    fn to_snake_from_sentence_or_kebab<'a>(non_snake_case_string: String) -> String {
-        return to_upper_case(non_snake_case_string.replace(" ", "_").replace("-", "_"));
+    fn to_snake_from_sentence_or_kebab(non_snake_case_string: String) -> String {
+        to_upper_case(non_snake_case_string.replace(" ", "_").replace("-", "_"))
     }
 
-/// Determines of a `String` is screaming_snake_case
+/// Determines of a `String` is `SCREAMING_SNAKE_CASE`
 ///
 /// #Examples
 /// ```
@@ -193,10 +193,10 @@ pub fn to_screaming_snake_case<'a>(non_snake_case_string: String) -> String {
 ///     assert!(asserted_bool == true);
 ///
 /// ```
-pub fn is_screaming_snake_case<'a>(test_string: String) -> bool{
+pub fn is_screaming_snake_case(test_string: String) -> bool{
     let snake_matcher = Regex::new(r"(?:[^-|^ ]?=^|[_])([A-Z]+)").unwrap();
     if snake_matcher.is_match(test_string.as_ref()){
         return true;
     }
-    return false;
+    false
 }

--- a/src/cases/sentencecase/mod.rs
+++ b/src/cases/sentencecase/mod.rs
@@ -4,7 +4,7 @@ use regex::Regex;
 use cases::classcase::is_class_case;
 use cases::snakecase::to_snake_case;
 
-/// Converts a `String` to Sentence case `String`
+/// Converts a `String` to `Sentence case` `String`
 ///
 /// #Examples
 /// ```
@@ -73,10 +73,10 @@ use cases::snakecase::to_snake_case;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_sentence_case<'a>(non_sentence_case_string: String) -> String {
-    return to_sentence_from_snake(to_snake_case(non_sentence_case_string));
+pub fn to_sentence_case(non_sentence_case_string: String) -> String {
+    to_sentence_from_snake(to_snake_case(non_sentence_case_string))
 }
-    fn to_sentence_from_snake<'a>(non_sentence_case_string: String) -> String {
+    fn to_sentence_from_snake(non_sentence_case_string: String) -> String {
         let mut result:String = "".to_string();
         let mut first_character: bool = true;
         for character in non_sentence_case_string.chars() {
@@ -89,10 +89,10 @@ pub fn to_sentence_case<'a>(non_sentence_case_string: String) -> String {
                 first_character = false;
             }
         }
-        return result
+        result
     }
 
-/// Determines of a `String` is Sentence case
+/// Determines of a `String` is `Sentence case`
 ///
 /// #Examples
 /// ```
@@ -185,12 +185,11 @@ pub fn to_sentence_case<'a>(non_sentence_case_string: String) -> String {
 ///     assert!(asserted_bool == true);
 ///
 /// ```
-pub fn is_sentence_case<'a>(test_string: String) -> bool{
+pub fn is_sentence_case(test_string: String) -> bool{
     let sentence_matcher= Regex::new(r"(^[A-Z])([^-|^_]*[ ][^A-Z][a-z0-9]+)").unwrap();
-    let mut is_sentence_case= false;
     if sentence_matcher.is_match(test_string.as_ref())
         && !is_class_case(test_string.clone()){
-            is_sentence_case = true;
+            return true;
         }
-    return is_sentence_case;
+    false
 }

--- a/src/cases/snakecase/mod.rs
+++ b/src/cases/snakecase/mod.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 
 use cases::lowercase::to_lower_case;
 
-/// Converts a `String` to snake_case `String`
+/// Converts a `String` to `snake_case` `String`
 ///
 /// #Examples
 /// ```
@@ -94,16 +94,16 @@ use cases::lowercase::to_lower_case;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_snake_case<'a>(non_snake_case_string: String) -> String {
-    if non_snake_case_string.contains(" ")
-        || non_snake_case_string.contains("_")
-        || non_snake_case_string.contains("-") {
-        return to_snake_from_sentence_or_kebab(non_snake_case_string);
+pub fn to_snake_case(non_snake_case_string: String) -> String {
+    if non_snake_case_string.contains(' ')
+        || non_snake_case_string.contains('_')
+        || non_snake_case_string.contains('-') {
+        to_snake_from_sentence_or_kebab(non_snake_case_string)
     } else {
-        return to_snake_from_camel_or_class(non_snake_case_string);
+        to_snake_from_camel_or_class(non_snake_case_string)
     }
 }
-    fn to_snake_from_camel_or_class <'a>(non_snake_case_string: String) -> String {
+    fn to_snake_from_camel_or_class (non_snake_case_string: String) -> String {
         let mut result:String = "".to_string();
         let mut first_character: bool = true;
         for character in non_snake_case_string.chars() {
@@ -114,14 +114,14 @@ pub fn to_snake_case<'a>(non_snake_case_string: String) -> String {
                 first_character = false;
             }
         }
-        return result
+        result
     }
 
-    fn to_snake_from_sentence_or_kebab<'a>(non_snake_case_string: String) -> String {
-        return to_lower_case(non_snake_case_string.replace(" ", "_").replace("-", "_"));
+    fn to_snake_from_sentence_or_kebab(non_snake_case_string: String) -> String {
+        to_lower_case(non_snake_case_string.replace(" ", "_").replace("-", "_"))
     }
 
-/// Determines of a `String` is snake_case
+/// Determines of a `String` is `snake_case`
 ///
 /// #Examples
 /// ```
@@ -214,10 +214,10 @@ pub fn to_snake_case<'a>(non_snake_case_string: String) -> String {
 ///     assert!(asserted_bool == true);
 ///
 /// ```
-pub fn is_snake_case<'a>(test_string: String) -> bool{
+pub fn is_snake_case(test_string: String) -> bool{
     let snake_matcher = Regex::new(r"(?:[^-|^ ]?=^|[_])([a-z]+)").unwrap();
     if snake_matcher.is_match(test_string.as_ref()){
         return true;
     }
-    return false;
+    false
 }

--- a/src/cases/tablecase/mod.rs
+++ b/src/cases/tablecase/mod.rs
@@ -2,7 +2,7 @@ use cases::snakecase::to_snake_case;
 use cases::sentencecase::to_sentence_case;
 use string::pluralize::to_plural;
 
-/// Converts a `String` to table-case `String`
+/// Converts a `String` to `table-case` `String`
 ///
 /// #Examples
 /// ```
@@ -74,22 +74,22 @@ use string::pluralize::to_plural;
 /// let asserted_string: String = to_table_case(mock_string);
 /// assert!(asserted_string == expected_string);
 /// ```
-pub fn to_table_case<'a>(non_table_case_string: String) -> String {
+pub fn to_table_case(non_table_case_string: String) -> String {
     let sentenceable_string: String = to_sentence_case(non_table_case_string.clone());
     let words: Vec<&str> = sentenceable_string.split(' ').collect();
     let mut sentence: String = "".to_string();
-    for word_index in 0..(words.len() - 1) {
+    for (word_index, _) in words.iter().enumerate().take((words.len() - 1)){
         if word_index == 0 {
-            sentence = format!("{}", words[word_index]);
+            sentence = words[word_index].to_string();
         } else {
             sentence = format!("{} {}", sentence, words[word_index]);
         }
     }
     sentence = format!("{} {}", sentence, to_plural(words[words.len() - 1].to_string()));
-    return to_snake_case(sentence);
+    to_snake_case(sentence)
 }
 
-/// Determines if a `String` is table-case
+/// Determines if a `String` is `table-case`
 ///
 /// #Examples
 /// ```
@@ -163,6 +163,6 @@ pub fn to_table_case<'a>(non_table_case_string: String) -> String {
 ///     let asserted_bool: bool = is_table_case(mock_string);
 ///     assert!(asserted_bool == false);
 /// ```
-pub fn is_table_case<'a>(test_string: String) -> bool {
-    return test_string.to_string() == to_table_case(test_string);
+pub fn is_table_case(test_string: String) -> bool {
+    test_string.clone() == to_table_case(test_string)
 }

--- a/src/cases/titlecase/mod.rs
+++ b/src/cases/titlecase/mod.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 
 use cases::snakecase::to_snake_case;
 
-/// Converts a `String` to Title Case `String`
+/// Converts a `String` to `Title Case` `String`
 ///
 /// #Examples
 /// ```
@@ -72,11 +72,11 @@ use cases::snakecase::to_snake_case;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_title_case<'a>(non_title_case_string: String) -> String {
-    return to_title_from_snake(to_snake_case(non_title_case_string));
+pub fn to_title_case(non_title_case_string: String) -> String {
+    to_title_from_snake(to_snake_case(non_title_case_string))
 }
 
-    fn to_title_from_snake<'a>(non_sentence_case_string: String) -> String {
+    fn to_title_from_snake(non_sentence_case_string: String) -> String {
         let mut result:String = "".to_string();
         let mut first_character: bool = true;
         for character in non_sentence_case_string.chars() {
@@ -90,10 +90,10 @@ pub fn to_title_case<'a>(non_title_case_string: String) -> String {
                 first_character = false;
             }
         }
-        return result.trim().to_string();
+        result.trim().to_string()
     }
 
-/// Determines if a `String` is Title Case
+/// Determines if a `String` is `Title Case`
 ///
 /// #Examples
 /// ```
@@ -176,11 +176,10 @@ pub fn to_title_case<'a>(non_title_case_string: String) -> String {
 ///     assert!(asserted_bool == true);
 ///
 /// ```
-pub fn is_title_case<'a>(test_string: String) -> bool{
+pub fn is_title_case(test_string: String) -> bool{
     let title_matcher= Regex::new(r"(^[A-Z][a-z0-9]+)([^-|^_]*[ ][A-Z][a-z0-9]+)").unwrap();
-    let mut is_title_case= false;
     if title_matcher.is_match(test_string.as_ref()) {
-        is_title_case = true;
+        return true;
     }
-    return is_title_case;
+    false
 }

--- a/src/cases/uppercase/mod.rs
+++ b/src/cases/uppercase/mod.rs
@@ -12,7 +12,7 @@
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_upper_case<'a>(non_upper_string: String) -> String {
+pub fn to_upper_case(non_upper_string: String) -> String {
     non_upper_string
         .chars()
         .flat_map(char::to_uppercase)
@@ -53,6 +53,6 @@ pub fn to_upper_case<'a>(non_upper_string: String) -> String {
 ///
 /// ```
 
-pub fn is_upper_case<'a>(test_string: String) -> bool{
+pub fn is_upper_case(test_string: String) -> bool{
     test_string == to_upper_case(test_string.to_owned())
 }

--- a/src/cases/uppercase/mod.rs
+++ b/src/cases/uppercase/mod.rs
@@ -1,6 +1,3 @@
-use std::ascii::*;
-use regex::Regex;
-
 /// Converts a `String` to uppercase `String`
 ///
 /// #Examples
@@ -15,12 +12,11 @@ use regex::Regex;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_upper_case<'a>(non_camelized_string: String) -> String {
-    let mut result:String = "".to_string();
-    for character in non_camelized_string.chars() {
-        result = format!("{}{}", result, character.to_ascii_uppercase());
-    }
-    return result
+pub fn to_upper_case<'a>(non_upper_string: String) -> String {
+    non_upper_string
+        .chars()
+        .flat_map(char::to_uppercase)
+        .collect()
 }
 
 /// Determines if a `String` is UPPERCASE
@@ -58,10 +54,5 @@ pub fn to_upper_case<'a>(non_camelized_string: String) -> String {
 /// ```
 
 pub fn is_upper_case<'a>(test_string: String) -> bool{
-    let upper_matcher = Regex::new(r"^[A-Z| |_|-]+$").unwrap();
-    let mut is_upper_case = false;
-    if upper_matcher.is_match(test_string.as_ref()){
-        is_upper_case = true;
-    }
-    return is_upper_case;
+    test_string == to_upper_case(test_string.to_owned())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
 #![deny(warnings)]
+#![feature(plugin)]
+#![plugin(clippy)]
+#![allow(doc_markdown)]
 
 //! [![Build Status](https://travis-ci.org/whatisinternet/inflector.svg?branch=master)](https://travis-ci.org/whatisinternet/inflector) [![Crates.io](https://img.shields.io/crates/v/inflector.svg)](https://crates.io/crates/inflector)
 //!
@@ -83,221 +86,221 @@ use string::pluralize::to_plural;
 use string::singularize::to_singular;
 
 pub trait Inflector {
-    fn to_class_case<'a>(&self) -> String;
-    fn is_class_case<'a>(&self) -> bool;
+    fn to_class_case(&self) -> String;
+    fn is_class_case(&self) -> bool;
 
-    fn to_camel_case<'a>(&self) -> String;
-    fn is_camel_case<'a>(&self) -> bool;
+    fn to_camel_case(&self) -> String;
+    fn is_camel_case(&self) -> bool;
 
-    fn to_table_case<'a>(&self) -> String;
-    fn is_table_case<'a>(&self) -> bool;
+    fn to_table_case(&self) -> String;
+    fn is_table_case(&self) -> bool;
 
-    fn to_snake_case<'a>(&self) -> String;
-    fn is_snake_case<'a>(&self) -> bool;
+    fn to_snake_case(&self) -> String;
+    fn is_snake_case(&self) -> bool;
 
-    fn to_screaming_snake_case<'a>(&self) -> String;
-    fn is_screaming_snake_case<'a>(&self) -> bool;
+    fn to_screaming_snake_case(&self) -> String;
+    fn is_screaming_snake_case(&self) -> bool;
 
-    fn to_kebab_case<'a>(&self) -> String;
-    fn is_kebab_case<'a>(&self) -> bool;
+    fn to_kebab_case(&self) -> String;
+    fn is_kebab_case(&self) -> bool;
 
-    fn to_sentence_case<'a>(&self) -> String;
-    fn is_sentence_case<'a>(&self) -> bool;
+    fn to_sentence_case(&self) -> String;
+    fn is_sentence_case(&self) -> bool;
 
-    fn to_title_case<'a>(&self) -> String;
-    fn is_title_case<'a>(&self) -> bool;
+    fn to_title_case(&self) -> String;
+    fn is_title_case(&self) -> bool;
 
-    fn to_upper_case<'a>(&self) -> String;
-    fn is_upper_case<'a>(&self) -> bool;
+    fn to_upper_case(&self) -> String;
+    fn is_upper_case(&self) -> bool;
 
-    fn to_lower_case<'a>(&self) -> String;
-    fn is_lower_case<'a>(&self) -> bool;
+    fn to_lower_case(&self) -> String;
+    fn is_lower_case(&self) -> bool;
 
-    fn ordinalize<'a>(&self) -> String;
-    fn deordinalize<'a>(&self) -> String;
+    fn ordinalize(&self) -> String;
+    fn deordinalize(&self) -> String;
 
-    fn to_foreign_key<'a>(&self) -> String;
-    fn is_foreign_key<'a>(&self) -> bool;
+    fn to_foreign_key(&self) -> String;
+    fn is_foreign_key(&self) -> bool;
 
-    fn demodulize<'a>(&self) -> String;
-    fn deconstantize<'a>(&self) -> String;
+    fn demodulize(&self) -> String;
+    fn deconstantize(&self) -> String;
 
-    fn to_plural<'a>(&self) -> String;
-    fn to_singular<'a>(&self) -> String;
+    fn to_plural(&self) -> String;
+    fn to_singular(&self) -> String;
 }
 
 impl<'c> Inflector for String {
     fn to_class_case(&self) -> String{
-        return to_class_case(self.to_string());
+        to_class_case(self.to_string())
     }
     fn is_class_case(&self) -> bool{
-        return is_class_case(self.to_string());
+        is_class_case(self.to_string())
     }
     fn to_camel_case(&self) -> String{
-        return to_camel_case(self.to_string());
+        to_camel_case(self.to_string())
     }
     fn is_camel_case(&self) -> bool{
-        return is_camel_case(self.to_string());
+        is_camel_case(self.to_string())
     }
     fn to_table_case(&self) -> String{
-        return to_table_case(self.to_string());
+        to_table_case(self.to_string())
     }
     fn is_table_case(&self) -> bool{
-        return is_table_case(self.to_string());
+        is_table_case(self.to_string())
     }
     fn to_screaming_snake_case(&self) -> String{
-        return to_screaming_snake_case(self.to_string());
+        to_screaming_snake_case(self.to_string())
     }
     fn is_screaming_snake_case(&self) -> bool{
-        return is_screaming_snake_case(self.to_string());
+        is_screaming_snake_case(self.to_string())
     }
     fn to_snake_case(&self) -> String{
-        return to_snake_case(self.to_string());
+        to_snake_case(self.to_string())
     }
     fn is_snake_case(&self) -> bool{
-        return is_snake_case(self.to_string());
+        is_snake_case(self.to_string())
     }
     fn to_kebab_case(&self) -> String{
-        return to_kebab_case(self.to_string());
+        to_kebab_case(self.to_string())
     }
     fn is_kebab_case(&self) -> bool{
-        return is_kebab_case(self.to_string());
+        is_kebab_case(self.to_string())
     }
     fn to_sentence_case(&self) -> String{
-        return to_sentence_case(self.to_string());
+        to_sentence_case(self.to_string())
     }
     fn is_sentence_case(&self) -> bool{
-        return is_sentence_case(self.to_string());
+        is_sentence_case(self.to_string())
     }
     fn to_title_case(&self) -> String{
-        return to_title_case(self.to_string());
+        to_title_case(self.to_string())
     }
     fn is_title_case(&self) -> bool{
-        return is_title_case(self.to_string());
+        is_title_case(self.to_string())
     }
     fn to_upper_case(&self) -> String{
-        return to_upper_case(self.to_string());
+        to_upper_case(self.to_string())
     }
     fn is_upper_case(&self) -> bool{
-        return is_upper_case(self.to_string());
+        is_upper_case(self.to_string())
     }
     fn to_lower_case(&self) -> String{
-        return to_lower_case(self.to_string());
+        to_lower_case(self.to_string())
     }
     fn is_lower_case(&self) -> bool{
-        return is_lower_case(self.to_string());
+        is_lower_case(self.to_string())
     }
     fn ordinalize(&self) -> String{
-        return ordinalize(self.to_string());
+        ordinalize(self.to_string())
     }
     fn deordinalize(&self) -> String{
-        return deordinalize(self.to_string());
+        deordinalize(self.to_string())
     }
     fn to_foreign_key(&self) -> String{
-        return to_foreign_key(self.to_string());
+        to_foreign_key(self.to_string())
     }
     fn is_foreign_key(&self) -> bool{
-        return is_foreign_key(self.to_string());
+        is_foreign_key(self.to_string())
     }
     fn demodulize(&self) -> String{
-        return demodulize(self.to_string());
+        demodulize(self.to_string())
     }
     fn deconstantize(&self) -> String{
-        return deconstantize(self.to_string());
+        deconstantize(self.to_string())
     }
     fn to_plural(&self) -> String{
-        return to_plural(self.to_string());
+        to_plural(self.to_string())
     }
     fn to_singular(&self) -> String{
-        return to_singular(self.to_string());
+        to_singular(self.to_string())
     }
 }
 
 impl<'c> Inflector for str {
     fn to_class_case(&self) -> String{
-        return to_class_case(self.to_string());
+        to_class_case(self.to_string())
     }
     fn is_class_case(&self) -> bool{
-        return is_class_case(self.to_string());
+        is_class_case(self.to_string())
     }
     fn to_camel_case(&self) -> String{
-        return to_camel_case(self.to_string());
+        to_camel_case(self.to_string())
     }
     fn is_camel_case(&self) -> bool{
-        return is_camel_case(self.to_string());
+        is_camel_case(self.to_string())
     }
     fn to_table_case(&self) -> String{
-        return to_table_case(self.to_string());
+        to_table_case(self.to_string())
     }
     fn is_table_case(&self) -> bool{
-        return is_table_case(self.to_string());
+        is_table_case(self.to_string())
     }
     fn to_screaming_snake_case(&self) -> String{
-        return to_screaming_snake_case(self.to_string());
+        to_screaming_snake_case(self.to_string())
     }
     fn is_screaming_snake_case(&self) -> bool{
-        return is_screaming_snake_case(self.to_string());
+        is_screaming_snake_case(self.to_string())
     }
     fn to_snake_case(&self) -> String{
-        return to_snake_case(self.to_string());
+        to_snake_case(self.to_string())
     }
     fn is_snake_case(&self) -> bool{
-        return is_snake_case(self.to_string());
+        is_snake_case(self.to_string())
     }
     fn to_kebab_case(&self) -> String{
-        return to_kebab_case(self.to_string());
+        to_kebab_case(self.to_string())
     }
     fn is_kebab_case(&self) -> bool{
-        return is_kebab_case(self.to_string());
+        is_kebab_case(self.to_string())
     }
     fn to_sentence_case(&self) -> String{
-        return to_sentence_case(self.to_string());
+        to_sentence_case(self.to_string())
     }
     fn is_sentence_case(&self) -> bool{
-        return is_sentence_case(self.to_string());
+        is_sentence_case(self.to_string())
     }
     fn to_title_case(&self) -> String{
-        return to_title_case(self.to_string());
+        to_title_case(self.to_string())
     }
     fn is_title_case(&self) -> bool{
-        return is_title_case(self.to_string());
+        is_title_case(self.to_string())
     }
     fn to_upper_case(&self) -> String{
-        return to_upper_case(self.to_string());
+        to_upper_case(self.to_string())
     }
     fn is_upper_case(&self) -> bool{
-        return is_upper_case(self.to_string());
+        is_upper_case(self.to_string())
     }
     fn to_lower_case(&self) -> String{
-        return to_lower_case(self.to_string());
+        to_lower_case(self.to_string())
     }
     fn is_lower_case(&self) -> bool{
-        return is_lower_case(self.to_string());
+        is_lower_case(self.to_string())
     }
     fn ordinalize(&self) -> String{
-        return ordinalize(self.to_string());
+        ordinalize(self.to_string())
     }
     fn deordinalize(&self) -> String{
-        return deordinalize(self.to_string());
+        deordinalize(self.to_string())
     }
     fn to_foreign_key(&self) -> String{
-        return to_foreign_key(self.to_string());
+        to_foreign_key(self.to_string())
     }
     fn is_foreign_key(&self) -> bool{
-        return is_foreign_key(self.to_string());
+        is_foreign_key(self.to_string())
     }
     fn demodulize(&self) -> String{
-        return demodulize(self.to_string());
+        demodulize(self.to_string())
     }
     fn deconstantize(&self) -> String{
-        return deconstantize(self.to_string());
+        deconstantize(self.to_string())
     }
 
     fn to_plural(&self) -> String{
-        return to_plural(self.to_string());
+        to_plural(self.to_string())
     }
 
     fn to_singular(&self) -> String{
-        return to_singular(self.to_string());
+        to_singular(self.to_string())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
-#![feature(plugin)]
-#![plugin(clippy)]
-#![allow(doc_markdown)]
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
+#![cfg_attr(feature="clippy", allow(doc_markdown))]
 
 //! [![Build Status](https://travis-ci.org/whatisinternet/inflector.svg?branch=master)](https://travis-ci.org/whatisinternet/inflector) [![Crates.io](https://img.shields.io/crates/v/inflector.svg)](https://crates.io/crates/inflector)
 //!

--- a/src/numbers/deordinalize/mod.rs
+++ b/src/numbers/deordinalize/mod.rs
@@ -144,15 +144,15 @@
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn deordinalize<'a>(non_ordinalized_string: String) -> String {
-    if non_ordinalized_string.contains(".")  {
-        return non_ordinalized_string;
+pub fn deordinalize(non_ordinalized_string: String) -> String {
+    if non_ordinalized_string.contains('.')  {
+        non_ordinalized_string
     } else {
-        return non_ordinalized_string
+        non_ordinalized_string
             .trim_right_matches("st")
             .trim_right_matches("nd")
             .trim_right_matches("rd")
             .trim_right_matches("th")
-            .to_string();
+            .to_string()
     }
 }

--- a/src/numbers/ordinalize/mod.rs
+++ b/src/numbers/ordinalize/mod.rs
@@ -155,7 +155,7 @@
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn ordinalize<'a>(non_ordinalized_string: String) -> String {
+pub fn ordinalize(non_ordinalized_string: String) -> String {
     let chars: Vec<char>= non_ordinalized_string.clone().chars().collect();
     let last_number: char= chars[chars.len() - 1];
     if !last_number.is_numeric() {
@@ -165,7 +165,7 @@ pub fn ordinalize<'a>(non_ordinalized_string: String) -> String {
         let second_last_number: char= chars[chars.len() - 2];
         if second_last_number == '1'{
             return format!("{}{}", non_ordinalized_string, "th");
-        } else if non_ordinalized_string.contains(".") {
+        } else if non_ordinalized_string.contains('.') {
             return non_ordinalized_string;
         }
     }

--- a/src/string/deconstantize/mod.rs
+++ b/src/string/deconstantize/mod.rs
@@ -47,15 +47,15 @@
 /// ```
 use cases::classcase::to_class_case;
 
-pub fn deconstantize<'a>(non_deconstantized_string: String) -> String {
+pub fn deconstantize(non_deconstantized_string: String) -> String {
     if non_deconstantized_string.contains("::") {
         let split_string: Vec<&str> = non_deconstantized_string.split("::").collect();
         if split_string.len() > 1 {
-            return format!("{}", to_class_case(split_string[split_string.len() - 2].to_string()));
+            to_class_case(split_string[split_string.len() - 2].to_string())
         } else {
-            return "".to_string();
+            "".to_string()
         }
     } else {
-        return "".to_string();
+        "".to_string()
     }
 }

--- a/src/string/demodulize/mod.rs
+++ b/src/string/demodulize/mod.rs
@@ -47,11 +47,11 @@
 /// ```
 use cases::classcase::to_class_case;
 
-pub fn demodulize<'a>(non_demodulize_string: String) -> String {
+pub fn demodulize(non_demodulize_string: String) -> String {
     if non_demodulize_string.contains("::") {
         let split_string: Vec<&str> = non_demodulize_string.split("::").collect();
-        return format!("{}", to_class_case(split_string[split_string.len() - 1].to_string()));
+        to_class_case(split_string[split_string.len() - 1].to_string())
     } else {
-        return non_demodulize_string;
+        non_demodulize_string
     }
 }

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -1,18 +1,18 @@
 /// Provides demodulize a string.
 ///
-/// Example string "Foo::Bar" becomes "Bar"
+/// Example string `Foo::Bar` becomes `Bar`
 pub mod demodulize;
 /// Provides deconstantizea string.
 ///
-/// Example string "Foo::Bar" becomes "Foo"
+/// Example string `Foo::Bar` becomes `Foo`
 pub mod deconstantize;
 /// Provides conversion to plural strings.
 ///
-/// Example string "FooBar" -> "FooBars"
+/// Example string `FooBar` -> `FooBars`
 pub mod pluralize;
 /// Provides conversion to singular strings.
 ///
-/// Example string "FooBars" -> "FooBar"
+/// Example string `FooBars` -> `FooBar`
 pub mod singularize;
 
 mod constants;

--- a/src/string/pluralize/mod.rs
+++ b/src/string/pluralize/mod.rs
@@ -1,3 +1,4 @@
+#![allow(trivial_regex)]
 use regex::Regex;
 use string::constants::UNACCONTABLE_WORDS;
 
@@ -95,22 +96,22 @@ const PLURAL_RULES: [&'static str; 20] = [
 ///
 /// ```
 ///
-pub fn to_plural<'a>(non_plural_string: String) -> String {
+pub fn to_plural(non_plural_string: String) -> String {
     if UNACCONTABLE_WORDS.contains(&non_plural_string.as_ref()) {
-        return non_plural_string;
+        non_plural_string
     } else {
         let plural_regexes: [Regex; 20] = plural_rules_regexes();
         for plural_index in 0..plural_regexes.len() {
-            if plural_regexes[plural_index].is_match(&non_plural_string.as_ref()) {
+            if plural_regexes[plural_index].is_match(&non_plural_string){
                 return format!("{}{}", non_plural_string, PLURAL_RULES[plural_index]);
             }
         }
 
-        return format!("{}s", non_plural_string);
+        format!("{}s", non_plural_string)
     }
 }
-    fn plural_rules_regexes<'a>() -> [Regex; 20] {
-        return [
+    fn plural_rules_regexes() -> [Regex; 20] {
+        [
             Regex::new(r"^(ox)$").unwrap(),
             Regex::new(r"^(ax|test)is$").unwrap(),
             Regex::new(r"(octop|vir)us$").unwrap(),
@@ -131,6 +132,6 @@ pub fn to_plural<'a>(non_plural_string: String) -> String {
             Regex::new(r"^(oxen)$").unwrap(),
             Regex::new(r"(quiz)$").unwrap(),
             Regex::new(r"s$").unwrap(),
-        ];
+        ]
 
     }

--- a/src/string/pluralize/mod.rs
+++ b/src/string/pluralize/mod.rs
@@ -1,4 +1,4 @@
-#![allow(trivial_regex)]
+#![cfg_attr(feature="clippy", allow(trivial_regex))]
 use regex::Regex;
 use string::constants::UNACCONTABLE_WORDS;
 

--- a/src/string/singularize/mod.rs
+++ b/src/string/singularize/mod.rs
@@ -1,3 +1,5 @@
+#![allow(needless_return)]
+#![allow(trivial_regex)]
 use regex::Regex;
 use regex::{Captures};
 use string::constants::UNACCONTABLE_WORDS;
@@ -103,21 +105,21 @@ const SINGULAR_RULES: [&'static str; 27] = [
 ///
 /// ```
 ///
-pub fn to_singular<'a>(non_singular_string: String) -> String {
+pub fn to_singular(non_singular_string: String) -> String {
     if UNACCONTABLE_WORDS.contains(&non_singular_string.as_ref()) {
-        return non_singular_string;
+        non_singular_string
     } else {
         let safe_out_string: String = non_singular_string.to_string();
         let maybe_regex_match: Option<String> = singularize_string(non_singular_string);
-        return maybe_regex_match.unwrap_or(safe_out_string);
+        maybe_regex_match.unwrap_or(safe_out_string)
     }
 }
 
-    fn singularize_string<'a>(non_singular_string: String) -> Option<String> {
+    fn singularize_string(non_singular_string: String) -> Option<String> {
         let singular_regexes: [Regex; 27] = singular_rules_regexes();
         for singular_index in 0..singular_regexes.len() {
             let maybe_match: Option<String> = singularize_string_from_capture_groups_if_match(
-                non_singular_string.to_string(), singular_index.clone());
+                non_singular_string.to_string(), singular_index);
 
             if maybe_match.is_some() {
                 return Some(maybe_match.unwrap_or(non_singular_string));
@@ -126,23 +128,22 @@ pub fn to_singular<'a>(non_singular_string: String) -> String {
         return None;
     }
 
-        fn singularize_string_from_capture_groups_if_match<'a>(non_singular_string: String,
+        fn singularize_string_from_capture_groups_if_match(non_singular_string: String,
                                                         singular_index: usize) -> Option<String> {
             let singular_regexes: [Regex; 27] = singular_rules_regexes();
 
-            if singular_regexes[singular_index].is_match(&non_singular_string.as_ref()) {
+            if singular_regexes[singular_index].is_match(&non_singular_string) {
 
                 let cap: Captures = singular_regexes[singular_index].captures(
-                    &non_singular_string.as_ref()).unwrap();
+                    &non_singular_string).unwrap();
 
-                return Some(singularize_string_from_capture_groups(cap, singular_index));
-
+                Some(singularize_string_from_capture_groups(cap, singular_index))
             } else {
-                return None;
+                None
             }
         }
 
-            fn singularize_string_from_capture_groups<'a>(capture_groups: Captures,
+            fn singularize_string_from_capture_groups(capture_groups: Captures,
                                                             singular_index: usize) -> String {
                 if capture_groups.len() > 2 {
 
@@ -158,8 +159,8 @@ pub fn to_singular<'a>(non_singular_string: String) -> String {
                 }
             }
 
-            fn singular_rules_regexes<'a>() -> [Regex; 27] {
-                return [
+            fn singular_rules_regexes() -> [Regex; 27] {
+                [
                     Regex::new(r"(n)ews$").unwrap(),
                     Regex::new(r"(\w*)(o)es$").unwrap(),
                     Regex::new(r"(\w*)([ti])a$").unwrap(),
@@ -187,7 +188,7 @@ pub fn to_singular<'a>(non_singular_string: String) -> String {
                     Regex::new(r"(database)s$").unwrap(),
                     Regex::new(r"(\w*)s$").unwrap(),
                     Regex::new(r"(\w*)(ss)$").unwrap()
-                ];
+                ]
 
             }
 
@@ -240,7 +241,7 @@ fn singularize_string_from_capture_groups_should_return_a_singularized_string() 
     let singular_regexes: [Regex; 27] = singular_rules_regexes();
     let singular_index: usize = 20;
     let cap: Captures = singular_regexes[singular_index].captures(
-        &test_string.as_ref()).unwrap();
+        &test_string).unwrap();
     let asserted_string: String = singularize_string_from_capture_groups(cap,singular_index);
     assert!(expected_string == asserted_string);
 

--- a/src/string/singularize/mod.rs
+++ b/src/string/singularize/mod.rs
@@ -1,5 +1,4 @@
-#![allow(needless_return)]
-#![allow(trivial_regex)]
+#![cfg_attr(feature="clippy", allow(needless_return, trivial_regex))]
 use regex::Regex;
 use regex::{Captures};
 use string::constants::UNACCONTABLE_WORDS;

--- a/src/suffix/foreignkey/mod.rs
+++ b/src/suffix/foreignkey/mod.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 
 use cases::snakecase::to_snake_case;
 
-/// Converts a `String` to a foreign_key
+/// Converts a `String` to a `foreign_key`
 ///
 /// #Examples
 /// ```
@@ -93,25 +93,22 @@ use cases::snakecase::to_snake_case;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_foreign_key<'a>(non_foreign_key_string: String) -> String {
+pub fn to_foreign_key(non_foreign_key_string: String) -> String {
     if is_foreign_key(non_foreign_key_string.clone()){
-        return non_foreign_key_string;
+        non_foreign_key_string
+    } else if non_foreign_key_string.contains("::") {
+        let split_string: Vec<&str> = non_foreign_key_string.split("::").collect();
+        safe_convert(split_string[split_string.len() - 1].to_string())
     } else {
-        if non_foreign_key_string.contains("::") {
-            let split_string: Vec<&str> = non_foreign_key_string.split("::").collect();
-            return safe_convert(split_string[split_string.len() - 1].to_string());
-
-        } else {
-            return safe_convert(non_foreign_key_string);
-        }
+        safe_convert(non_foreign_key_string)
     }
 }
-    fn safe_convert<'a>(safe_string: String) -> String{
+    fn safe_convert(safe_string: String) -> String{
         let snake_cased: String = to_snake_case(safe_string);
-        return format!("{}{}", snake_cased, "_id");
+        format!("{}{}", snake_cased, "_id")
     }
 
-/// Determines if a `String` is a foreign_key
+/// Determines if a `String` is a `foreign_key`
 ///
 /// #Examples
 /// ```
@@ -184,14 +181,13 @@ pub fn to_foreign_key<'a>(non_foreign_key_string: String) -> String {
 ///     assert!(asserted_bool == true);
 ///
 /// ```
-pub fn is_foreign_key<'a>(test_string: String) -> bool{
+pub fn is_foreign_key(test_string: String) -> bool{
     let foreign_key_matcher= Regex::new(r"(?:[^-|^ ]?=^|[_])([a-z]+)").unwrap();
     let upcase_matcher = Regex::new(r"[A-Z]").unwrap();
-    let mut is_foreign_key: bool = false;
     if foreign_key_matcher.is_match(test_string.as_ref())
         && !upcase_matcher.is_match(test_string.as_ref())
         && test_string.ends_with("_id"){
-            is_foreign_key= true;
+            return true;
         }
-    return is_foreign_key;
+    false
 }

--- a/src/suffix/mod.rs
+++ b/src/suffix/mod.rs
@@ -1,4 +1,4 @@
 /// Provides foreign key conversion for String.
 ///
-/// Example string "foo" becomes "foo_id"
+/// Example string `foo` becomes `foo_id`
 pub mod foreignkey;


### PR DESCRIPTION
Now uses the Rust 1.2 built in lower and upper case implementations.
This should provide a small performance improvement over the old
implementation.

This change breaks for Rust < 1.2.

Closes #19 