### PR TITLE
Chore/stable fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Inflector"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Josh Teeter<joshteeter@gmail.com>"]
 exclude = [".travis.yml", ".gitignore"]
 readme = "README.md"
@@ -20,5 +20,5 @@ name = "inflector"
 path = "src/lib.rs"
 
 [dependencies]
-regex = "0.1.41"
+regex = "0.1.73"
 lazy_static = "0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![deny(warnings)]
 
-//! [![Build Status](https://travis-ci.org/whatisinternet/inflector.svg?branch=master)](https://travis-ci.org/whatisinternet/inflector) [![Crates.io](https://img.shields.io/crates/v/inflector.svg)](https://crates.io/crates/inflector)
-
 //! Adds String based inflections for Rust. Snake, kebab, camel,
 //! sentence, class, title, upper, and lower cases as well as ordinalize,
 //! deordinalize, demodulize, deconstantize, and foreign key are supported as

--- a/src/string/pluralize/mod.rs
+++ b/src/string/pluralize/mod.rs
@@ -1,16 +1,17 @@
+#![deny(warnings)]
 use regex::Regex;
 use string::constants::UNACCONTABLE_WORDS;
 
 macro_rules! add_rule{
-    ($r:ident, $rule:expr => $replace:expr) =>{
+    ($r:ident, $rule:expr => $replace:expr) => {
         $r.push((Regex::new($rule).unwrap(), $replace));
     }
 }
 
 macro_rules! rules{
-    ($r:ident; $($rule:expr => $replace:expr), *) =>{
+    ($r:ident; $($rule:expr => $replace:expr), *) => {
         $(
-            add_rule!($r, $rule => $replace)
+            add_rule!{$r, $rule => $replace}
         )*
     }
 }


### PR DESCRIPTION
# What it does:
- Fixes issues with `macros` as outlined [here](https://github.com/rust-lang/rust/pull/34660#issuecomment-231211751)


# Why it does it:
- The code denies warning and will fail to build on newer versions of rust


# Related issues:
https://github.com/rust-lang/rust/pull/34660


