### PR TITLE
Enhancement/performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Inflector"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Josh Teeter<joshteeter@gmail.com>"]
 exclude = [".travis.yml", ".gitignore"]
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Documentation can be found here at the README or via rust docs below.
 
 ```toml
 [dependencies]
-Inflector = "0.3.1"
+Inflector = "0.3.2"
 ```
 
 ### Compile yourself:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,83 @@
+# 0.3.2
+
+## Fixes:
+
+- Fixes issue https://github.com/rust-lang/rust/pull/3466://github.com/whatisinternet/inflector/issues/18
+- Fixes performance issues overall
+
+## Benchmarks:
+```shell
+test cases::camelcase::tests::bench_camel0                      ... bench:         139 ns/iter (+/- 40)
+test cases::camelcase::tests::bench_camel1                      ... bench:         138 ns/iter (+/- 31)
+test cases::camelcase::tests::bench_camel2                      ... bench:         138 ns/iter (+/- 41)
+test cases::camelcase::tests::bench_is_camel                    ... bench:         184 ns/iter (+/- 90)
+test cases::classcase::tests::bench_class_case                  ... bench:       2,383 ns/iter (+/- 557)
+test cases::classcase::tests::bench_class_from_snake            ... bench:       2,393 ns/iter (+/- 1,120)
+test cases::classcase::tests::bench_is_class                    ... bench:       2,443 ns/iter (+/- 1,060)
+test cases::kebabcase::tests::bench_is_kebab                    ... bench:         182 ns/iter (+/- 60)
+test cases::kebabcase::tests::bench_kebab                       ... bench:         161 ns/iter (+/- 98)
+test cases::kebabcase::tests::bench_kebab_from_snake            ... bench:         264 ns/iter (+/- 144)
+test cases::lowercase::tests::bench_is_lower                    ... bench:         358 ns/iter (+/- 154)
+test cases::lowercase::tests::bench_lower                       ... bench:         347 ns/iter (+/- 220)
+test cases::screamingsnakecase::tests::bench_is_screaming_snake ... bench:         194 ns/iter (+/- 35)
+test cases::screamingsnakecase::tests::bench_screaming_snake    ... bench:         173 ns/iter (+/- 97)
+test cases::sentencecase::tests::bench_is_sentence              ... bench:         377 ns/iter (+/- 83)
+test cases::sentencecase::tests::bench_sentence                 ... bench:         337 ns/iter (+/- 155)
+test cases::sentencecase::tests::bench_sentence_from_snake      ... bench:         370 ns/iter (+/- 176)
+test cases::snakecase::tests::bench_is_snake                    ... bench:         191 ns/iter (+/- 98)
+test cases::snakecase::tests::bench_snake_from_camel            ... bench:         156 ns/iter (+/- 25)
+test cases::snakecase::tests::bench_snake_from_snake            ... bench:         289 ns/iter (+/- 136)
+test cases::snakecase::tests::bench_snake_from_title            ... bench:         157 ns/iter (+/- 68)
+test cases::tablecase::tests::bench_is_table_case               ... bench:       2,253 ns/iter (+/- 978)
+test cases::tablecase::tests::bench_table_case                  ... bench:       2,227 ns/iter (+/- 704)
+test cases::titlecase::tests::bench_is_title                    ... bench:         787 ns/iter (+/- 362)
+test cases::titlecase::tests::bench_title                       ... bench:         826 ns/iter (+/- 317)
+test cases::titlecase::tests::bench_title_from_snake            ... bench:         747 ns/iter (+/- 230)
+test cases::uppercase::tests::bench_is_upper                    ... bench:         347 ns/iter (+/- 111)
+test cases::uppercase::tests::bench_upper                       ... bench:         328 ns/iter (+/- 42)
+```
+
+## OLD Benchmarks:
+```shell
+test cases::camelcase::tests::bench_camel                                         ... bench:       1,825 ns/iter (+/- 346)
+test cases::camelcase::tests::bench_camel_from_sname                              ... bench:       1,223 ns/iter (+/- 289)
+test cases::camelcase::tests::bench_is_camel                                      ... bench:      49,416 ns/iter (+/- 593)
+test cases::classcase::tests::bench_class_case                                    ... bench: 160,985,376 ns/iter (+/- 5,173,751)
+test cases::classcase::tests::bench_class_from_snake                              ... bench: 161,533,425 ns/iter (+/- 4,167,305)
+test cases::classcase::tests::bench_is_class                                      ... bench: 161,352,118 ns/iter (+/- 3,793,478)
+test cases::kebabcase::tests::bench_is_kebab                                      ... bench:         793 ns/iter (+/- 400)
+test cases::kebabcase::tests::bench_kebab                                         ... bench:         752 ns/iter (+/- 310)
+test cases::kebabcase::tests::bench_kebab_from_snake                              ... bench:         210 ns/iter (+/- 32)
+test cases::lowercase::tests::bench_is_lower                                      ... bench:         340 ns/iter (+/- 86)
+test cases::lowercase::tests::bench_lower                                         ... bench:         306 ns/iter (+/- 173)
+test cases::screamingsnakecase::tests::bench_is_screaming_snake                   ... bench:         635 ns/iter (+/- 210)
+test cases::screamingsnakecase::tests::bench_screaming_snake                      ... bench:         610 ns/iter (+/- 87)
+test cases::screamingsnakecase::tests::bench_screaming_snake_from_camel           ... bench:         961 ns/iter (+/- 579)
+test cases::screamingsnakecase::tests::bench_screaming_snake_from_class           ... bench:         894 ns/iter (+/- 352)
+test cases::screamingsnakecase::tests::bench_screaming_snake_from_kebab           ... bench:         877 ns/iter (+/- 571)
+test cases::screamingsnakecase::tests::bench_screaming_snake_from_screaming_snake ... bench:         584 ns/iter (+/- 304)
+test cases::screamingsnakecase::tests::bench_screaming_snake_from_sentence        ... bench:       1,123 ns/iter (+/- 630)
+test cases::screamingsnakecase::tests::bench_screaming_snake_from_upper_kebab     ... bench:         914 ns/iter (+/- 435)
+test cases::sentencecase::tests::bench_is_sentence                                ... bench:       2,714 ns/iter (+/- 796)
+test cases::sentencecase::tests::bench_sentence                                   ... bench:       2,678 ns/iter (+/- 1,357)
+test cases::sentencecase::tests::bench_sentence_from_snake                        ... bench:       2,100 ns/iter (+/- 1,046)
+test cases::snakecase::tests::bench_is_snake                                      ... bench:         626 ns/iter (+/- 191)
+test cases::snakecase::tests::bench_snake                                         ... bench:         581 ns/iter (+/- 298)
+test cases::snakecase::tests::bench_snake_from_camel                              ... bench:         882 ns/iter (+/- 328)
+test cases::snakecase::tests::bench_snake_from_class                              ... bench:         883 ns/iter (+/- 193)
+test cases::snakecase::tests::bench_snake_from_kebab                              ... bench:         922 ns/iter (+/- 360)
+test cases::snakecase::tests::bench_snake_from_sentence                           ... bench:       1,209 ns/iter (+/- 539)
+test cases::snakecase::tests::bench_snake_from_snake                              ... bench:         637 ns/iter (+/- 386)
+test cases::snakecase::tests::bench_snake_from_upper_kebab                        ... bench:         876 ns/iter (+/- 488)
+test cases::tablecase::tests::bench_is_table_case                                 ... bench:       5,784 ns/iter (+/- 1,129)
+test cases::tablecase::tests::bench_table_case                                    ... bench:       5,754 ns/iter (+/- 1,460)
+test cases::titlecase::tests::bench_is_title                                      ... bench:       2,847 ns/iter (+/- 1,553)
+test cases::titlecase::tests::bench_title                                         ... bench:       2,799 ns/iter (+/- 1,309)
+test cases::titlecase::tests::bench_title_from_snake                              ... bench:       2,202 ns/iter (+/- 697)
+test cases::uppercase::tests::bench_is_upper                                      ... bench:         357 ns/iter (+/- 55)
+test cases::uppercase::tests::bench_upper                                         ... bench:         311 ns/iter (+/- 135)
+```
+
 # 0.3.1
 
 ## Fixes:

--- a/src/cases/camelcase/mod.rs
+++ b/src/cases/camelcase/mod.rs
@@ -182,3 +182,24 @@ pub fn is_camel_case(test_string: String) -> bool {
     }
     false
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate test;
+    use self::test::Bencher;
+
+    #[bench]
+    fn bench_camel(b: &mut Bencher) {
+        b.iter(|| super::to_camel_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_is_camel(b: &mut Bencher) {
+        b.iter(|| super::is_camel_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_camel_from_sname(b: &mut Bencher) {
+        b.iter(|| super::to_camel_from_snake("foo_bar".to_string()));
+    }
+}

--- a/src/cases/camelcase/mod.rs
+++ b/src/cases/camelcase/mod.rs
@@ -71,7 +71,7 @@ pub fn to_camel_case(non_camelized_string: String) -> String {
     let mut last_char: char = ' ';
     non_camelized_string
         .chars()
-        .fold("".to_string(), |result, character|
+        .fold("".to_string(), |mut result, character|
             if character == '-' || character == '_' || character == ' ' {
                 new_word = true;
                 result
@@ -80,10 +80,12 @@ pub fn to_camel_case(non_camelized_string: String) -> String {
                 (last_char != ' ')
                 ){
                 new_word = false;
-                format!("{}{}", result, character.to_ascii_uppercase())
+                result.push(character.to_ascii_uppercase());
+                result
             } else {
                 last_char = character;
-                format!("{}{}", result, character.to_ascii_lowercase())
+                result.push(character.to_ascii_lowercase());
+                result
             }
         )
 }
@@ -180,21 +182,35 @@ mod tests {
 
     #[bench]
     fn bench_camel0(b: &mut Bencher) {
-        b.iter(|| super::to_camel_case("Foo bar".to_string()));
+        b.iter(|| {
+            let test_string = "Foo bar".to_string();
+            super::to_camel_case(test_string)
+        });
     }
 
     #[bench]
     fn bench_camel1(b: &mut Bencher) {
-        b.iter(|| super::to_camel_case("foo_bar".to_string()));
+        b.iter(|| {
+            let test_string = "foo_bar".to_string();
+            super::to_camel_case(test_string)
+        }
+        );
     }
 
     #[bench]
     fn bench_camel2(b: &mut Bencher) {
-        b.iter(|| super::to_camel_case("fooBar".to_string()));
+        b.iter(|| {
+            let test_string = "fooBar".to_string();
+            super::to_camel_case(test_string)
+        });
     }
 
     #[bench]
     fn bench_is_camel(b: &mut Bencher) {
-        b.iter(|| super::is_camel_case("Foo bar".to_string()));
+        b.iter(|| {
+            let test_string: String  = "Foo bar".to_string();
+            super::is_camel_case(test_string)
+        }
+        );
     }
 }

--- a/src/cases/camelcase/mod.rs
+++ b/src/cases/camelcase/mod.rs
@@ -1,13 +1,8 @@
 use std::ascii::*;
-use regex::Regex;
-
-use cases::classcase::is_class_case;
-use cases::snakecase::to_snake_case;
-
 /// Converts a `String` to camelCase `String`
 ///
 /// #Examples
-/// ```
+/// ```0
 ///     use inflector::cases::camelcase::to_camel_case;
 ///     let mock_string: String = "fooBar".to_string();
 ///     let expected_string: String = "fooBar".to_string();
@@ -15,7 +10,7 @@ use cases::snakecase::to_snake_case;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-/// ```
+/// ```1
 ///     use inflector::cases::camelcase::to_camel_case;
 ///     let mock_string: String = "FOO_BAR".to_string();
 ///     let expected_string: String = "fooBar".to_string();
@@ -23,7 +18,7 @@ use cases::snakecase::to_snake_case;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-/// ```
+/// ```2
 ///     use inflector::cases::camelcase::to_camel_case;
 ///     let mock_string: String = "Foo Bar".to_string();
 ///     let expected_string: String = "fooBar".to_string();
@@ -31,7 +26,7 @@ use cases::snakecase::to_snake_case;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-/// ```
+/// ```3
 ///     use inflector::cases::camelcase::to_camel_case;
 ///     let mock_string: String = "foo_bar".to_string();
 ///     let expected_string: String = "fooBar".to_string();
@@ -39,7 +34,7 @@ use cases::snakecase::to_snake_case;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-/// ```
+/// ```4
 ///     use inflector::cases::camelcase::to_camel_case;
 ///     let mock_string: String = "Foo bar".to_string();
 ///     let expected_string: String = "fooBar".to_string();
@@ -47,7 +42,7 @@ use cases::snakecase::to_snake_case;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-/// ```
+/// ```5
 ///     use inflector::cases::camelcase::to_camel_case;
 ///     let mock_string: String = "foo-bar".to_string();
 ///     let expected_string: String = "fooBar".to_string();
@@ -55,7 +50,7 @@ use cases::snakecase::to_snake_case;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-/// ```
+/// ```6
 ///     use inflector::cases::camelcase::to_camel_case;
 ///     let mock_string: String = "FooBar".to_string();
 ///     let expected_string: String = "fooBar".to_string();
@@ -63,7 +58,7 @@ use cases::snakecase::to_snake_case;
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-/// ```
+/// ```7
 ///     use inflector::cases::camelcase::to_camel_case;
 ///     let mock_string: String = "FooBar3".to_string();
 ///     let expected_string: String = "fooBar3".to_string();
@@ -72,30 +67,31 @@ use cases::snakecase::to_snake_case;
 ///
 /// ```
 pub fn to_camel_case(non_camelized_string: String) -> String {
-    to_camel_from_snake(to_snake_case(non_camelized_string))
-}
-
-fn to_camel_from_snake(non_camelized_string: String) -> String {
-    let mut result: String = "".to_string();
     let mut new_word: bool = false;
-
-    for character in non_camelized_string.chars() {
-        if character.to_string() == "_" {
-            new_word = true;
-        } else if new_word {
-            result = format!("{}{}", result, character.to_ascii_uppercase());
-            new_word = false;
-        } else {
-            result = format!("{}{}", result, character.to_ascii_lowercase());
-        }
-    }
-    result
+    let mut last_char: char = ' ';
+    non_camelized_string
+        .chars()
+        .fold("".to_string(), |result, character|
+            if character == '-' || character == '_' || character == ' ' {
+                new_word = true;
+                result
+            } else if new_word || (
+                (last_char.is_lowercase() && character.is_uppercase()) &&
+                (last_char != ' ')
+                ){
+                new_word = false;
+                format!("{}{}", result, character.to_ascii_uppercase())
+            } else {
+                last_char = character;
+                format!("{}{}", result, character.to_ascii_lowercase())
+            }
+        )
 }
 
 /// Determines if a `String` is camelCase bool``
 ///
 /// #Examples
-/// ```
+/// ```0
 ///     use inflector::cases::camelcase::is_camel_case;
 ///     let mock_string: String = "Foo".to_string();
 ///     let asserted_bool: bool = is_camel_case(mock_string);
@@ -103,15 +99,15 @@ fn to_camel_from_snake(non_camelized_string: String) -> String {
 ///
 ///
 /// ```
-/// ```
+/// ```1
 ///     use inflector::cases::camelcase::is_camel_case;
 ///     let mock_string: String = "foo".to_string();
 ///     let asserted_bool: bool = is_camel_case(mock_string);
-///     assert!(asserted_bool == false);
+///     assert!(asserted_bool == true);
 ///
 ///
 /// ```
-/// ```
+/// ```2
 ///     use inflector::cases::camelcase::is_camel_case;
 ///     let mock_string: String = "foo-bar-string-that-is-really-really-long".to_string();
 ///     let asserted_bool: bool = is_camel_case(mock_string);
@@ -119,7 +115,7 @@ fn to_camel_from_snake(non_camelized_string: String) -> String {
 ///
 ///
 /// ```
-/// ```
+/// ```3
 ///     use inflector::cases::camelcase::is_camel_case;
 ///     let mock_string: String = "FooBarIsAReallyReallyLongString".to_string();
 ///     let asserted_bool: bool = is_camel_case(mock_string);
@@ -127,7 +123,7 @@ fn to_camel_from_snake(non_camelized_string: String) -> String {
 ///
 ///
 /// ```
-/// ```
+/// ```4
 ///     use inflector::cases::camelcase::is_camel_case;
 ///     let mock_string: String = "fooBarIsAReallyReally3LongString".to_string();
 ///     let asserted_bool: bool = is_camel_case(mock_string);
@@ -135,7 +131,7 @@ fn to_camel_from_snake(non_camelized_string: String) -> String {
 ///
 ///
 /// ```
-/// ```
+/// ```5
 ///     use inflector::cases::camelcase::is_camel_case;
 ///     let mock_string: String = "fooBarIsAReallyReallyLongString".to_string();
 ///     let asserted_bool: bool = is_camel_case(mock_string);
@@ -143,7 +139,7 @@ fn to_camel_from_snake(non_camelized_string: String) -> String {
 ///
 ///
 /// ```
-/// ```
+/// ```6
 ///     use inflector::cases::camelcase::is_camel_case;
 ///     let mock_string: String = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG".to_string();
 ///     let asserted_bool: bool = is_camel_case(mock_string);
@@ -151,7 +147,7 @@ fn to_camel_from_snake(non_camelized_string: String) -> String {
 ///
 ///
 /// ```
-/// ```
+/// ```7
 ///     use inflector::cases::camelcase::is_camel_case;
 ///     let mock_string: String = "foo_bar_string_that_is_really_really_long".to_string();
 ///     let asserted_bool: bool = is_camel_case(mock_string);
@@ -159,7 +155,7 @@ fn to_camel_from_snake(non_camelized_string: String) -> String {
 ///
 ///
 /// ```
-/// ```
+/// ```8
 ///     use inflector::cases::camelcase::is_camel_case;
 ///     let mock_string: String = "Foo bar string that is really really long".to_string();
 ///     let asserted_bool: bool = is_camel_case(mock_string);
@@ -167,20 +163,14 @@ fn to_camel_from_snake(non_camelized_string: String) -> String {
 ///
 ///
 /// ```
-/// ```
+/// ```9
 ///     use inflector::cases::camelcase::is_camel_case;
 ///     let mock_string: String = "Foo Bar Is A Really Really Long String".to_string();
 ///     let asserted_bool: bool = is_camel_case(mock_string);
 ///     assert!(asserted_bool == false);
 /// ```
 pub fn is_camel_case(test_string: String) -> bool {
-    let camel_matcher = Regex::new(r"(^|[A-Z])([^-|^_|^ ]*[a-z0-9]+[A-Z][a-z0-9]+)").unwrap();
-    let kebab_snake_matcher = Regex::new(r"[-|_| ]").unwrap();
-    if camel_matcher.is_match(test_string.as_ref()) &&
-       !kebab_snake_matcher.is_match(test_string.as_ref()) && !is_class_case(test_string) {
-        return true;
-    }
-    false
+    to_camel_case(test_string.clone()) == test_string
 }
 
 #[cfg(test)]
@@ -189,17 +179,22 @@ mod tests {
     use self::test::Bencher;
 
     #[bench]
-    fn bench_camel(b: &mut Bencher) {
+    fn bench_camel0(b: &mut Bencher) {
         b.iter(|| super::to_camel_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_camel1(b: &mut Bencher) {
+        b.iter(|| super::to_camel_case("foo_bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_camel2(b: &mut Bencher) {
+        b.iter(|| super::to_camel_case("fooBar".to_string()));
     }
 
     #[bench]
     fn bench_is_camel(b: &mut Bencher) {
         b.iter(|| super::is_camel_case("Foo bar".to_string()));
-    }
-
-    #[bench]
-    fn bench_camel_from_sname(b: &mut Bencher) {
-        b.iter(|| super::to_camel_from_snake("foo_bar".to_string()));
     }
 }

--- a/src/cases/camelcase/mod.rs
+++ b/src/cases/camelcase/mod.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use std::ascii::*;
 /// Converts a `String` to camelCase `String`
 ///
@@ -175,7 +176,7 @@ pub fn is_camel_case(test_string: String) -> bool {
     to_camel_case(test_string.clone()) == test_string
 }
 
-#[cfg(test)]
+#[cfg(all(feature = "unstable", test))]
 mod tests {
     extern crate test;
     use self::test::Bencher;

--- a/src/cases/case/mod.rs
+++ b/src/cases/case/mod.rs
@@ -1,0 +1,45 @@
+use std::ascii::*;
+
+pub fn to_case_snake_like(
+    convertable_string: String,
+    replace_with: &str,
+    case: &str
+    ) -> String {
+    let seperators: &[char] = &[' ', '-', '_'];
+    if convertable_string.contains(seperators) {
+        if case == "lower" {
+            convertable_string.replace(seperators, replace_with).to_lowercase()
+        } else {
+            convertable_string.replace(seperators, replace_with).to_uppercase()
+        }
+    } else {
+        to_snake_like_from_camel_or_class(convertable_string, replace_with, case)
+    }
+}
+
+
+fn to_snake_like_from_camel_or_class(
+    convertable_string: String,
+    replace_with: &str,
+    case: &str
+    ) -> String {
+    let mut first_character: bool = true;
+    convertable_string
+        .chars()
+        .fold("".to_string(), |acc, character|
+              if character == character.to_ascii_uppercase() && !first_character {
+                  if case == "lower" {
+                    format!("{}{}{}", acc, replace_with, character.to_ascii_lowercase())
+                  } else {
+                    format!("{}{}{}", acc, replace_with, character.to_ascii_uppercase())
+                  }
+              } else {
+                  first_character = false;
+                  if case == "lower" {
+                    format!("{}{}", acc, character.to_ascii_lowercase())
+                  } else {
+                    format!("{}{}", acc, character.to_ascii_uppercase())
+                  }
+              }
+        )
+}

--- a/src/cases/case/mod.rs
+++ b/src/cases/case/mod.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use std::ascii::*;
 
 pub fn to_case_snake_like(

--- a/src/cases/case/mod.rs
+++ b/src/cases/case/mod.rs
@@ -7,16 +7,48 @@ pub fn to_case_snake_like(
     ) -> String {
     let seperators: &[char] = &[' ', '-', '_'];
     if convertable_string.contains(seperators) {
-        if case == "lower" {
-            convertable_string.replace(seperators, replace_with).to_lowercase()
-        } else {
-            convertable_string.replace(seperators, replace_with).to_uppercase()
-        }
+        to_snake_like_from_snake_like(convertable_string, replace_with, case)
     } else {
         to_snake_like_from_camel_or_class(convertable_string, replace_with, case)
     }
 }
 
+fn to_snake_like_from_snake_like(
+    convertable_string: String,
+    replace_with: &str,
+    case: &str
+    ) -> String {
+    let mut new_word: bool = false;
+    let mut last_char: char = ' ';
+    convertable_string
+        .chars()
+        .fold("".to_string(), |mut result, character|
+            if character == '-' || character == '_' || character == ' ' {
+                new_word = true;
+                result.push(replace_with.chars().nth(0).unwrap_or('_'));
+                result
+            } else if new_word || (
+                (last_char.is_lowercase() && character.is_uppercase()) &&
+                (last_char != ' ')
+                ){
+                new_word = false;
+                if case == "lower" {
+                    result.push(character.to_ascii_lowercase());
+                } else {
+                    result.push(character.to_ascii_uppercase());
+                }
+                result
+            } else {
+                last_char = character;
+                if case == "lower" {
+                    result.push(character.to_ascii_lowercase());
+                } else {
+                    result.push(character.to_ascii_uppercase());
+                }
+                result
+            }
+        )
+}
 
 fn to_snake_like_from_camel_or_class(
     convertable_string: String,
@@ -26,19 +58,25 @@ fn to_snake_like_from_camel_or_class(
     let mut first_character: bool = true;
     convertable_string
         .chars()
-        .fold("".to_string(), |acc, character|
+        .fold("".to_string(), |mut acc, character|
               if character == character.to_ascii_uppercase() && !first_character {
                   if case == "lower" {
-                    format!("{}{}{}", acc, replace_with, character.to_ascii_lowercase())
+                    acc.push(replace_with.chars().nth(0).unwrap_or('_'));
+                    acc.push(character.to_ascii_lowercase());
+                    acc
                   } else {
-                    format!("{}{}{}", acc, replace_with, character.to_ascii_uppercase())
+                    acc.push(replace_with.chars().nth(0).unwrap_or('_'));
+                    acc.push(character.to_ascii_uppercase());
+                    acc
                   }
               } else {
                   first_character = false;
                   if case == "lower" {
-                    format!("{}{}", acc, character.to_ascii_lowercase())
+                    acc.push(character.to_ascii_lowercase());
+                    acc
                   } else {
-                    format!("{}{}", acc, character.to_ascii_uppercase())
+                    acc.push(character.to_ascii_uppercase());
+                    acc
                   }
               }
         )

--- a/src/cases/classcase/mod.rs
+++ b/src/cases/classcase/mod.rs
@@ -202,3 +202,24 @@ fn to_class_from_snake(non_class_case_string: String) -> String {
 pub fn is_class_case(test_string: String) -> bool {
     test_string == to_class_case(test_string.clone())
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate test;
+    use self::test::Bencher;
+
+    #[bench]
+    fn bench_class_case(b: &mut Bencher) {
+        b.iter(|| super::to_class_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_is_class(b: &mut Bencher) {
+        b.iter(|| super::is_class_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_class_from_snake(b: &mut Bencher) {
+        b.iter(|| super::to_class_from_snake("foo_bar".to_string()));
+    }
+}

--- a/src/cases/classcase/mod.rs
+++ b/src/cases/classcase/mod.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use std::ascii::*;
 use string::singularize::to_singular;
 /// Converts a `String` to `ClassCase` `String`
@@ -204,7 +205,7 @@ pub fn is_class_case(test_string: String) -> bool {
     test_string == to_class_case(test_string.clone())
 }
 
-#[cfg(test)]
+#[cfg(all(feature = "unstable", test))]
 mod tests {
     extern crate test;
     use self::test::Bencher;

--- a/src/cases/classcase/mod.rs
+++ b/src/cases/classcase/mod.rs
@@ -1,8 +1,5 @@
 use std::ascii::*;
-
-use cases::snakecase::to_snake_case;
 use string::singularize::to_singular;
-
 /// Converts a `String` to `ClassCase` `String`
 ///
 /// #Examples
@@ -87,26 +84,28 @@ use string::singularize::to_singular;
 ///
 /// ```
 pub fn to_class_case(non_class_case_string: String) -> String {
-    to_class_from_snake(to_snake_case(non_class_case_string))
-}
-fn to_class_from_snake(non_class_case_string: String) -> String {
-    let singularized_word: String = to_singular(non_class_case_string);
-    let mut result: String = "".to_string();
     let mut new_word: bool = true;
-
-    for character in singularized_word.chars() {
-        if character.to_string() == "_" {
-            new_word = true;
-        } else if new_word {
-            result = format!("{}{}", result, character.to_ascii_uppercase());
-            new_word = false;
-        } else {
-            result = format!("{}{}", result, character.to_ascii_lowercase());
-        }
-    }
-    result
+    let mut last_char: char = ' ';
+    let class_plural = non_class_case_string
+        .chars()
+        .fold("".to_string(), |result, character|
+            if character == '-' || character == '_' || character == ' ' {
+                new_word = true;
+                result
+            } else if new_word || (
+                (last_char.is_lowercase() && character.is_uppercase()) &&
+                (last_char != ' ')
+                ){
+                new_word = false;
+                format!("{}{}", result, character.to_ascii_uppercase())
+            } else {
+                last_char = character;
+                format!("{}{}", result, character.to_ascii_lowercase())
+            }
+        );
+    let split: (&str, &str) = class_plural.split_at(class_plural.rfind(char::is_uppercase).unwrap_or(0));
+    format!("{}{}", split.0, to_singular(split.1.to_string()))
 }
-
 /// Determines if a `String` is `ClassCase` `bool`
 ///
 /// #Examples
@@ -208,18 +207,18 @@ mod tests {
     extern crate test;
     use self::test::Bencher;
 
-    // #[bench]
-    // fn bench_class_case(b: &mut Bencher) {
-    //     b.iter(|| super::to_class_case("Foo bar".to_string()));
-    // }
-    //
-    // #[bench]
-    // fn bench_is_class(b: &mut Bencher) {
-    //     b.iter(|| super::is_class_case("Foo bar".to_string()));
-    // }
-    //
-    // #[bench]
-    // fn bench_class_from_snake(b: &mut Bencher) {
-    //     b.iter(|| super::to_class_from_snake("foo_bar".to_string()));
-    // }
+    #[bench]
+    fn bench_class_case(b: &mut Bencher) {
+        b.iter(|| super::to_class_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_is_class(b: &mut Bencher) {
+        b.iter(|| super::is_class_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_class_from_snake(b: &mut Bencher) {
+        b.iter(|| super::to_class_case("foo_bar".to_string()));
+    }
 }

--- a/src/cases/classcase/mod.rs
+++ b/src/cases/classcase/mod.rs
@@ -88,7 +88,7 @@ pub fn to_class_case(non_class_case_string: String) -> String {
     let mut last_char: char = ' ';
     let class_plural = non_class_case_string
         .chars()
-        .fold("".to_string(), |result, character|
+        .fold("".to_string(), |mut result, character|
             if character == '-' || character == '_' || character == ' ' {
                 new_word = true;
                 result
@@ -97,10 +97,12 @@ pub fn to_class_case(non_class_case_string: String) -> String {
                 (last_char != ' ')
                 ){
                 new_word = false;
-                format!("{}{}", result, character.to_ascii_uppercase())
+                result.push(character.to_ascii_uppercase());
+                result
             } else {
                 last_char = character;
-                format!("{}{}", result, character.to_ascii_lowercase())
+                result.push(character.to_ascii_lowercase());
+                result
             }
         );
     let split: (&str, &str) = class_plural.split_at(class_plural.rfind(char::is_uppercase).unwrap_or(0));

--- a/src/cases/classcase/mod.rs
+++ b/src/cases/classcase/mod.rs
@@ -208,18 +208,18 @@ mod tests {
     extern crate test;
     use self::test::Bencher;
 
-    #[bench]
-    fn bench_class_case(b: &mut Bencher) {
-        b.iter(|| super::to_class_case("Foo bar".to_string()));
-    }
-
-    #[bench]
-    fn bench_is_class(b: &mut Bencher) {
-        b.iter(|| super::is_class_case("Foo bar".to_string()));
-    }
-
-    #[bench]
-    fn bench_class_from_snake(b: &mut Bencher) {
-        b.iter(|| super::to_class_from_snake("foo_bar".to_string()));
-    }
+    // #[bench]
+    // fn bench_class_case(b: &mut Bencher) {
+    //     b.iter(|| super::to_class_case("Foo bar".to_string()));
+    // }
+    //
+    // #[bench]
+    // fn bench_is_class(b: &mut Bencher) {
+    //     b.iter(|| super::is_class_case("Foo bar".to_string()));
+    // }
+    //
+    // #[bench]
+    // fn bench_class_from_snake(b: &mut Bencher) {
+    //     b.iter(|| super::to_class_from_snake("foo_bar".to_string()));
+    // }
 }

--- a/src/cases/kebabcase/mod.rs
+++ b/src/cases/kebabcase/mod.rs
@@ -1,4 +1,4 @@
-use cases::snakecase::to_snake_case;
+use cases::case::*;
 /// Determines if a `String` is `kebab-case`
 ///
 /// #Examples
@@ -128,10 +128,7 @@ pub fn is_kebab_case(test_string: String) -> bool {
 ///
 /// ```
 pub fn to_kebab_case(non_kebab_case_string: String) -> String {
-    to_kebab_from_snake(to_snake_case(non_kebab_case_string))
-}
-fn to_kebab_from_snake(non_kebab_case_string: String) -> String {
-    non_kebab_case_string.replace("_", "-")
+    to_case_snake_like(non_kebab_case_string, "-", "lower")
 }
 
 #[cfg(test)]
@@ -151,6 +148,6 @@ mod tests {
 
     #[bench]
     fn bench_kebab_from_snake(b: &mut Bencher) {
-        b.iter(|| super::to_kebab_from_snake("test_test_test".to_string()));
+        b.iter(|| super::to_kebab_case("test_test_test".to_string()));
     }
 }

--- a/src/cases/kebabcase/mod.rs
+++ b/src/cases/kebabcase/mod.rs
@@ -133,3 +133,24 @@ pub fn to_kebab_case(non_kebab_case_string: String) -> String {
 fn to_kebab_from_snake(non_kebab_case_string: String) -> String {
     non_kebab_case_string.replace("_", "-")
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate test;
+    use self::test::Bencher;
+
+    #[bench]
+    fn bench_kebab(b: &mut Bencher) {
+        b.iter(|| super::to_kebab_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_is_kebab(b: &mut Bencher) {
+        b.iter(|| super::is_kebab_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_kebab_from_snake(b: &mut Bencher) {
+        b.iter(|| super::to_kebab_from_snake("test_test_test".to_string()));
+    }
+}

--- a/src/cases/kebabcase/mod.rs
+++ b/src/cases/kebabcase/mod.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use cases::case::*;
 /// Determines if a `String` is `kebab-case`
 ///
@@ -131,7 +132,7 @@ pub fn to_kebab_case(non_kebab_case_string: String) -> String {
     to_case_snake_like(non_kebab_case_string, "-", "lower")
 }
 
-#[cfg(test)]
+#[cfg(all(feature = "unstable", test))]
 mod tests {
     extern crate test;
     use self::test::Bencher;

--- a/src/cases/lowercase/mod.rs
+++ b/src/cases/lowercase/mod.rs
@@ -9,6 +9,7 @@
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
+#[deprecated(since="0.3.2", note="Please use the standard `.to_lowercase()`")]
 pub fn to_lower_case(non_lower_string: String) -> String {
     // See https://github.com/calebmer/inflections/blob/master/src/case.rs#L37 for where this
     // implementation comes from.
@@ -41,6 +42,7 @@ pub fn to_lower_case(non_lower_string: String) -> String {
 ///     assert!(asserted_bool == false);
 ///
 /// ```
+#[deprecated(since="0.3.2", note="Please use the standard `.is_lowercase()`")]
 pub fn is_lower_case(test_string: String) -> bool {
     test_string == to_lower_case(test_string.clone())
 }

--- a/src/cases/lowercase/mod.rs
+++ b/src/cases/lowercase/mod.rs
@@ -44,3 +44,19 @@ pub fn to_lower_case(non_lower_string: String) -> String {
 pub fn is_lower_case(test_string: String) -> bool {
     test_string == to_lower_case(test_string.clone())
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate test;
+    use self::test::Bencher;
+
+    #[bench]
+    fn bench_lower(b: &mut Bencher) {
+        b.iter(|| super::to_lower_case("Foo BAR".to_string()));
+    }
+
+    #[bench]
+    fn bench_is_lower(b: &mut Bencher) {
+        b.iter(|| super::is_lower_case("Foo bar".to_string()));
+    }
+}

--- a/src/cases/lowercase/mod.rs
+++ b/src/cases/lowercase/mod.rs
@@ -47,7 +47,7 @@ pub fn is_lower_case(test_string: String) -> bool {
     test_string == to_lower_case(test_string.clone())
 }
 
-#[cfg(test)]
+#[cfg(all(feature = "unstable", test))]
 mod tests {
     extern crate test;
     use self::test::Bencher;

--- a/src/cases/mod.rs
+++ b/src/cases/mod.rs
@@ -47,3 +47,5 @@ pub mod uppercase;
 ///
 /// Example string `LOWERCASE`
 pub mod lowercase;
+
+mod case;

--- a/src/cases/screamingsnakecase/mod.rs
+++ b/src/cases/screamingsnakecase/mod.rs
@@ -1,5 +1,4 @@
 use std::ascii::*;
-use cases::uppercase::to_upper_case;
 
 /// Converts a `String` to `SCREAMING_SNAKE_CASE` `String`
 ///
@@ -83,7 +82,7 @@ fn to_snake_from_camel_or_class(non_snake_case_string: String) -> String {
 }
 
 fn to_snake_from_sentence_or_kebab(non_snake_case_string: String) -> String {
-    to_upper_case(non_snake_case_string.replace(" ", "_").replace("-", "_"))
+    non_snake_case_string.replace(" ", "_").replace("-", "_").to_uppercase()
 }
 
 /// Determines of a `String` is `SCREAMING_SNAKE_CASE`

--- a/src/cases/screamingsnakecase/mod.rs
+++ b/src/cases/screamingsnakecase/mod.rs
@@ -148,3 +148,50 @@ fn to_snake_from_sentence_or_kebab(non_snake_case_string: String) -> String {
 pub fn is_screaming_snake_case(test_string: String) -> bool {
     test_string == to_screaming_snake_case(test_string.clone())
 }
+
+
+#[cfg(test)]
+mod tests {
+    extern crate test;
+    use self::test::Bencher;
+
+    #[bench]
+    fn bench_screaming_snake(b: &mut Bencher) {
+        b.iter(|| super::to_screaming_snake_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_is_screaming_snake(b: &mut Bencher) {
+        b.iter(|| super::is_screaming_snake_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_screaming_snake_from_kebab(b: &mut Bencher) {
+        b.iter(|| super::to_snake_from_sentence_or_kebab("test-test-test".to_string()));
+    }
+
+    #[bench]
+    fn bench_screaming_snake_from_upper_kebab(b: &mut Bencher) {
+        b.iter(|| super::to_snake_from_sentence_or_kebab("TEST-TEST-TEST".to_string()));
+    }
+
+    #[bench]
+    fn bench_screaming_snake_from_screaming_snake(b: &mut Bencher) {
+        b.iter(|| super::to_snake_from_sentence_or_kebab("test_case".to_string()));
+    }
+
+    #[bench]
+    fn bench_screaming_snake_from_sentence(b: &mut Bencher) {
+        b.iter(|| super::to_snake_from_sentence_or_kebab("The quick brown fox".to_string()));
+    }
+
+    #[bench]
+    fn bench_screaming_snake_from_camel(b: &mut Bencher) {
+        b.iter(|| super::to_snake_from_camel_or_class("testCase".to_string()));
+    }
+
+    #[bench]
+    fn bench_screaming_snake_from_class(b: &mut Bencher) {
+        b.iter(|| super::to_snake_from_camel_or_class("TestCase".to_string()));
+    }
+}

--- a/src/cases/screamingsnakecase/mod.rs
+++ b/src/cases/screamingsnakecase/mod.rs
@@ -1,5 +1,6 @@
 use std::ascii::*;
 
+use cases::snakecase::to_snake_case;
 /// Converts a `String` to `SCREAMING_SNAKE_CASE` `String`
 ///
 /// #Examples
@@ -60,29 +61,7 @@ use std::ascii::*;
 ///
 /// ```
 pub fn to_screaming_snake_case(non_snake_case_string: String) -> String {
-    if non_snake_case_string.contains(' ') || non_snake_case_string.contains('_') ||
-       non_snake_case_string.contains('-') {
-        to_snake_from_sentence_or_kebab(non_snake_case_string)
-    } else {
-        to_snake_from_camel_or_class(non_snake_case_string)
-    }
-}
-fn to_snake_from_camel_or_class(non_snake_case_string: String) -> String {
-    let mut result: String = "".to_string();
-    let mut first_character: bool = true;
-    for character in non_snake_case_string.chars() {
-        if character == character.to_ascii_uppercase() && !first_character {
-            result = format!("{}_{}", result, character.to_ascii_uppercase());
-        } else {
-            result = format!("{}{}", result, character.to_ascii_uppercase());
-            first_character = false;
-        }
-    }
-    result
-}
-
-fn to_snake_from_sentence_or_kebab(non_snake_case_string: String) -> String {
-    non_snake_case_string.replace(" ", "_").replace("-", "_").to_uppercase()
+    to_snake_case(non_snake_case_string).to_uppercase()
 }
 
 /// Determines of a `String` is `SCREAMING_SNAKE_CASE`
@@ -162,35 +141,5 @@ mod tests {
     #[bench]
     fn bench_is_screaming_snake(b: &mut Bencher) {
         b.iter(|| super::is_screaming_snake_case("Foo bar".to_string()));
-    }
-
-    #[bench]
-    fn bench_screaming_snake_from_kebab(b: &mut Bencher) {
-        b.iter(|| super::to_snake_from_sentence_or_kebab("test-test-test".to_string()));
-    }
-
-    #[bench]
-    fn bench_screaming_snake_from_upper_kebab(b: &mut Bencher) {
-        b.iter(|| super::to_snake_from_sentence_or_kebab("TEST-TEST-TEST".to_string()));
-    }
-
-    #[bench]
-    fn bench_screaming_snake_from_screaming_snake(b: &mut Bencher) {
-        b.iter(|| super::to_snake_from_sentence_or_kebab("test_case".to_string()));
-    }
-
-    #[bench]
-    fn bench_screaming_snake_from_sentence(b: &mut Bencher) {
-        b.iter(|| super::to_snake_from_sentence_or_kebab("The quick brown fox".to_string()));
-    }
-
-    #[bench]
-    fn bench_screaming_snake_from_camel(b: &mut Bencher) {
-        b.iter(|| super::to_snake_from_camel_or_class("testCase".to_string()));
-    }
-
-    #[bench]
-    fn bench_screaming_snake_from_class(b: &mut Bencher) {
-        b.iter(|| super::to_snake_from_camel_or_class("TestCase".to_string()));
     }
 }

--- a/src/cases/screamingsnakecase/mod.rs
+++ b/src/cases/screamingsnakecase/mod.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use cases::case::*;
 /// Converts a `String` to `SCREAMING_SNAKE_CASE` `String`
 ///
@@ -126,7 +127,7 @@ pub fn is_screaming_snake_case(test_string: String) -> bool {
 }
 
 
-#[cfg(test)]
+#[cfg(all(feature = "unstable", test))]
 mod tests {
     extern crate test;
     use self::test::Bencher;

--- a/src/cases/screamingsnakecase/mod.rs
+++ b/src/cases/screamingsnakecase/mod.rs
@@ -1,6 +1,4 @@
-use std::ascii::*;
-
-use cases::snakecase::to_snake_case;
+use cases::case::*;
 /// Converts a `String` to `SCREAMING_SNAKE_CASE` `String`
 ///
 /// #Examples
@@ -61,7 +59,7 @@ use cases::snakecase::to_snake_case;
 ///
 /// ```
 pub fn to_screaming_snake_case(non_snake_case_string: String) -> String {
-    to_snake_case(non_snake_case_string).to_uppercase()
+    to_case_snake_like(non_snake_case_string, "_", "upper")
 }
 
 /// Determines of a `String` is `SCREAMING_SNAKE_CASE`

--- a/src/cases/sentencecase/mod.rs
+++ b/src/cases/sentencecase/mod.rs
@@ -1,6 +1,4 @@
-use std::ascii::*;
-use cases::snakecase::to_snake_case;
-
+use cases::case::*;
 /// Converts a `String` to `Sentence case` `String`
 ///
 /// #Examples
@@ -53,24 +51,10 @@ use cases::snakecase::to_snake_case;
 ///
 /// ```
 pub fn to_sentence_case(non_sentence_case_string: String) -> String {
-    to_sentence_from_snake(to_snake_case(non_sentence_case_string))
+    let snake_cased: String = to_case_snake_like(non_sentence_case_string, " ", "lower");
+    let split_on_first: (&str, &str) = snake_cased.split_at(1);
+    format!("{}{}", split_on_first.0.to_uppercase(), split_on_first.1)
 }
-fn to_sentence_from_snake(non_sentence_case_string: String) -> String {
-    let mut result: String = "".to_string();
-    let mut first_character: bool = true;
-    for character in non_sentence_case_string.chars() {
-        if character.to_string() != "_" && character.to_string() != "-" && !first_character {
-            result = format!("{}{}", result, character.to_ascii_lowercase());
-        } else if character.to_string() == "_" || character.to_string() == "-" {
-            result = format!("{} ", result);
-        } else {
-            result = format!("{}{}", result, character.to_ascii_uppercase());
-            first_character = false;
-        }
-    }
-    result
-}
-
 /// Determines of a `String` is `Sentence case`
 ///
 /// #Examples
@@ -158,6 +142,6 @@ mod tests {
 
     #[bench]
     fn bench_sentence_from_snake(b: &mut Bencher) {
-        b.iter(|| super::to_sentence_from_snake("foo_bar".to_string()));
+        b.iter(|| super::to_sentence_case("foo_bar".to_string()));
     }
 }

--- a/src/cases/sentencecase/mod.rs
+++ b/src/cases/sentencecase/mod.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use cases::case::*;
 /// Converts a `String` to `Sentence case` `String`
 ///
@@ -125,7 +126,7 @@ pub fn is_sentence_case(test_string: String) -> bool {
     test_string == to_sentence_case(test_string.clone())
 }
 
-#[cfg(test)]
+#[cfg(all(feature = "unstable", test))]
 mod tests {
     extern crate test;
     use self::test::Bencher;

--- a/src/cases/sentencecase/mod.rs
+++ b/src/cases/sentencecase/mod.rs
@@ -140,3 +140,24 @@ fn to_sentence_from_snake(non_sentence_case_string: String) -> String {
 pub fn is_sentence_case(test_string: String) -> bool {
     test_string == to_sentence_case(test_string.clone())
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate test;
+    use self::test::Bencher;
+
+    #[bench]
+    fn bench_sentence(b: &mut Bencher) {
+        b.iter(|| super::to_sentence_case("Foo BAR".to_string()));
+    }
+
+    #[bench]
+    fn bench_is_sentence(b: &mut Bencher) {
+        b.iter(|| super::is_sentence_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_sentence_from_snake(b: &mut Bencher) {
+        b.iter(|| super::to_sentence_from_snake("foo_bar".to_string()));
+    }
+}

--- a/src/cases/snakecase/mod.rs
+++ b/src/cases/snakecase/mod.rs
@@ -1,3 +1,4 @@
+use std::ascii::*;
 /// Converts a `String` to `snake_case` `String`
 ///
 /// #Examples
@@ -73,22 +74,22 @@ pub fn to_snake_case(non_snake_case_string: String) -> String {
         let tokens: Vec<&str> = non_snake_case_string.split(seperators).collect();
         tokens.join("_").to_lowercase()
     } else {
-        let converted: Vec<String> = non_snake_case_string
-            .chars()
-            .enumerate()
-            .map(|(i, s)|
-                 if (s.is_uppercase() == true || s.is_numeric()) && (i > 0 as usize) {
-                     format!("_{}", s)
-                 } else {
-                     s.to_string()
-                 }
-                 )
-            .collect();
-
-        converted
-            .join("")
-            .to_lowercase()
+        to_snake_from_camel_or_class(non_snake_case_string)
     }
+}
+
+fn to_snake_from_camel_or_class(non_snake_case_string: String) -> String {
+    let mut result: String = "".to_string();
+    let mut first_character: bool = true;
+    for character in non_snake_case_string.chars() {
+        if character == character.to_ascii_uppercase() && !first_character {
+            result = format!("{}_{}", result, character.to_ascii_lowercase());
+        } else {
+            result = format!("{}{}", result, character.to_ascii_lowercase());
+            first_character = false;
+        }
+    }
+    result
 }
 
 /// Determines of a `String` is `snake_case`

--- a/src/cases/snakecase/mod.rs
+++ b/src/cases/snakecase/mod.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use cases::case::*;
 /// Converts a `String` to `snake_case` `String`
 ///
@@ -140,7 +141,7 @@ pub fn is_snake_case(test_string: String) -> bool {
     test_string == to_snake_case(test_string.clone())
 }
 
-#[cfg(test)]
+#[cfg(all(feature = "unstable", test))]
 mod tests {
     extern crate test;
     use self::test::Bencher;

--- a/src/cases/snakecase/mod.rs
+++ b/src/cases/snakecase/mod.rs
@@ -1,4 +1,4 @@
-use std::ascii::*;
+use cases::case::*;
 /// Converts a `String` to `snake_case` `String`
 ///
 /// #Examples
@@ -67,29 +67,7 @@ use std::ascii::*;
 ///
 /// ```
 pub fn to_snake_case(non_snake_case_string: String) -> String {
-    if non_snake_case_string.contains(' ') ||
-        non_snake_case_string.contains('_') ||
-            non_snake_case_string.contains('-') {
-        let seperators: &[char] = &[' ', '-', '_'];
-        let tokens: Vec<&str> = non_snake_case_string.split(seperators).collect();
-        tokens.join("_").to_lowercase()
-    } else {
-        to_snake_from_camel_or_class(non_snake_case_string)
-    }
-}
-
-fn to_snake_from_camel_or_class(non_snake_case_string: String) -> String {
-    let mut result: String = "".to_string();
-    let mut first_character: bool = true;
-    for character in non_snake_case_string.chars() {
-        if character == character.to_ascii_uppercase() && !first_character {
-            result = format!("{}_{}", result, character.to_ascii_lowercase());
-        } else {
-            result = format!("{}{}", result, character.to_ascii_lowercase());
-            first_character = false;
-        }
-    }
-    result
+    to_case_snake_like(non_snake_case_string, "_", "lower")
 }
 
 /// Determines of a `String` is `snake_case`
@@ -179,7 +157,7 @@ mod tests {
 
     #[bench]
     fn bench_snake_from_snake(b: &mut Bencher) {
-        b.iter(|| super::to_snake_case("foo_bar".to_string()));
+        b.iter(|| super::to_snake_case("foo_bar_bar_bar".to_string()));
     }
 
     #[bench]

--- a/src/cases/snakecase/mod.rs
+++ b/src/cases/snakecase/mod.rs
@@ -76,6 +76,7 @@ pub fn to_snake_case(non_snake_case_string: String) -> String {
         to_snake_from_camel_or_class(non_snake_case_string)
     }
 }
+
 fn to_snake_from_camel_or_class(non_snake_case_string: String) -> String {
     let mut result: String = "".to_string();
     let mut first_character: bool = true;
@@ -162,4 +163,50 @@ fn to_snake_from_sentence_or_kebab(non_snake_case_string: String) -> String {
 /// ```
 pub fn is_snake_case(test_string: String) -> bool {
     test_string == to_snake_case(test_string.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate test;
+    use self::test::Bencher;
+
+    #[bench]
+    fn bench_snake(b: &mut Bencher) {
+        b.iter(|| super::to_snake_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_is_snake(b: &mut Bencher) {
+        b.iter(|| super::is_snake_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_snake_from_kebab(b: &mut Bencher) {
+        b.iter(|| super::to_snake_from_sentence_or_kebab("test-test-test".to_string()));
+    }
+
+    #[bench]
+    fn bench_snake_from_upper_kebab(b: &mut Bencher) {
+        b.iter(|| super::to_snake_from_sentence_or_kebab("TEST-TEST-TEST".to_string()));
+    }
+
+    #[bench]
+    fn bench_snake_from_snake(b: &mut Bencher) {
+        b.iter(|| super::to_snake_from_sentence_or_kebab("test_case".to_string()));
+    }
+
+    #[bench]
+    fn bench_snake_from_sentence(b: &mut Bencher) {
+        b.iter(|| super::to_snake_from_sentence_or_kebab("The quick brown fox".to_string()));
+    }
+
+    #[bench]
+    fn bench_snake_from_camel(b: &mut Bencher) {
+        b.iter(|| super::to_snake_from_camel_or_class("testCase".to_string()));
+    }
+
+    #[bench]
+    fn bench_snake_from_class(b: &mut Bencher) {
+        b.iter(|| super::to_snake_from_camel_or_class("TestCase".to_string()));
+    }
 }

--- a/src/cases/snakecase/mod.rs
+++ b/src/cases/snakecase/mod.rs
@@ -1,6 +1,3 @@
-use std::ascii::*;
-use cases::lowercase::to_lower_case;
-
 /// Converts a `String` to `snake_case` `String`
 ///
 /// #Examples
@@ -69,30 +66,29 @@ use cases::lowercase::to_lower_case;
 ///
 /// ```
 pub fn to_snake_case(non_snake_case_string: String) -> String {
-    if non_snake_case_string.contains(' ') || non_snake_case_string.contains('_') ||
-       non_snake_case_string.contains('-') {
-        to_snake_from_sentence_or_kebab(non_snake_case_string)
+    if non_snake_case_string.contains(' ') ||
+        non_snake_case_string.contains('_') ||
+            non_snake_case_string.contains('-') {
+        let seperators: &[char] = &[' ', '-', '_'];
+        let tokens: Vec<&str> = non_snake_case_string.split(seperators).collect();
+        tokens.join("_").to_lowercase()
     } else {
-        to_snake_from_camel_or_class(non_snake_case_string)
-    }
-}
+        let converted: Vec<String> = non_snake_case_string
+            .chars()
+            .enumerate()
+            .map(|(i, s)|
+                 if (s.is_uppercase() == true || s.is_numeric()) && (i > 0 as usize) {
+                     format!("_{}", s)
+                 } else {
+                     s.to_string()
+                 }
+                 )
+            .collect();
 
-fn to_snake_from_camel_or_class(non_snake_case_string: String) -> String {
-    let mut result: String = "".to_string();
-    let mut first_character: bool = true;
-    for character in non_snake_case_string.chars() {
-        if character == character.to_ascii_uppercase() && !first_character {
-            result = format!("{}_{}", result, character.to_ascii_lowercase());
-        } else {
-            result = format!("{}{}", result, character.to_ascii_lowercase());
-            first_character = false;
-        }
+        converted
+            .join("")
+            .to_lowercase()
     }
-    result
-}
-
-fn to_snake_from_sentence_or_kebab(non_snake_case_string: String) -> String {
-    to_lower_case(non_snake_case_string.replace(" ", "_").replace("-", "_"))
 }
 
 /// Determines of a `String` is `snake_case`
@@ -171,42 +167,22 @@ mod tests {
     use self::test::Bencher;
 
     #[bench]
-    fn bench_snake(b: &mut Bencher) {
+    fn bench_snake_from_title(b: &mut Bencher) {
         b.iter(|| super::to_snake_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_snake_from_camel(b: &mut Bencher) {
+        b.iter(|| super::to_snake_case("fooBar".to_string()));
+    }
+
+    #[bench]
+    fn bench_snake_from_snake(b: &mut Bencher) {
+        b.iter(|| super::to_snake_case("foo_bar".to_string()));
     }
 
     #[bench]
     fn bench_is_snake(b: &mut Bencher) {
         b.iter(|| super::is_snake_case("Foo bar".to_string()));
-    }
-
-    #[bench]
-    fn bench_snake_from_kebab(b: &mut Bencher) {
-        b.iter(|| super::to_snake_from_sentence_or_kebab("test-test-test".to_string()));
-    }
-
-    #[bench]
-    fn bench_snake_from_upper_kebab(b: &mut Bencher) {
-        b.iter(|| super::to_snake_from_sentence_or_kebab("TEST-TEST-TEST".to_string()));
-    }
-
-    #[bench]
-    fn bench_snake_from_snake(b: &mut Bencher) {
-        b.iter(|| super::to_snake_from_sentence_or_kebab("test_case".to_string()));
-    }
-
-    #[bench]
-    fn bench_snake_from_sentence(b: &mut Bencher) {
-        b.iter(|| super::to_snake_from_sentence_or_kebab("The quick brown fox".to_string()));
-    }
-
-    #[bench]
-    fn bench_snake_from_camel(b: &mut Bencher) {
-        b.iter(|| super::to_snake_from_camel_or_class("testCase".to_string()));
-    }
-
-    #[bench]
-    fn bench_snake_from_class(b: &mut Bencher) {
-        b.iter(|| super::to_snake_from_camel_or_class("TestCase".to_string()));
     }
 }

--- a/src/cases/tablecase/mod.rs
+++ b/src/cases/tablecase/mod.rs
@@ -76,7 +76,6 @@ pub fn to_table_case(non_table_case_string: String) -> String {
                        to_plural(words[words.len() - 1].to_string()));
     to_snake_case(sentence)
 }
-
 /// Determines if a `String` is `table-case`
 ///
 /// #Examples
@@ -138,4 +137,20 @@ pub fn to_table_case(non_table_case_string: String) -> String {
 /// ```
 pub fn is_table_case(test_string: String) -> bool {
     test_string.clone() == to_table_case(test_string)
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate test;
+    use self::test::Bencher;
+
+    #[bench]
+    fn bench_table_case(b: &mut Bencher) {
+        b.iter(|| super::to_table_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_is_table_case(b: &mut Bencher) {
+        b.iter(|| super::is_table_case("Foo bar".to_string()));
+    }
 }

--- a/src/cases/tablecase/mod.rs
+++ b/src/cases/tablecase/mod.rs
@@ -1,7 +1,5 @@
-use cases::snakecase::to_snake_case;
-use cases::sentencecase::to_sentence_case;
 use string::pluralize::to_plural;
-
+use cases::case::*;
 /// Converts a `String` to `table-case` `String`
 ///
 /// #Examples
@@ -61,20 +59,9 @@ use string::pluralize::to_plural;
 /// assert!(asserted_string == expected_string);
 /// ```
 pub fn to_table_case(non_table_case_string: String) -> String {
-    let sentenceable_string: String = to_sentence_case(non_table_case_string.clone());
-    let words: Vec<&str> = sentenceable_string.split(' ').collect();
-    let mut sentence: String = "".to_string();
-    for (word_index, _) in words.iter().enumerate().take((words.len() - 1)) {
-        if word_index == 0 {
-            sentence = words[word_index].to_string();
-        } else {
-            sentence = format!("{} {}", sentence, words[word_index]);
-        }
-    }
-    sentence = format!("{} {}",
-                       sentence,
-                       to_plural(words[words.len() - 1].to_string()));
-    to_snake_case(sentence)
+    let snaked: String = to_case_snake_like(non_table_case_string, "_", "lower");
+    let split: (&str, &str) = snaked.split_at(snaked.rfind('_').unwrap_or(0));
+    format!("{}{}", split.0, to_plural(split.1.to_string()))
 }
 /// Determines if a `String` is `table-case`
 ///

--- a/src/cases/tablecase/mod.rs
+++ b/src/cases/tablecase/mod.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use string::pluralize::to_plural;
 use cases::case::*;
 /// Converts a `String` to `table-case` `String`
@@ -126,7 +127,7 @@ pub fn is_table_case(test_string: String) -> bool {
     test_string.clone() == to_table_case(test_string)
 }
 
-#[cfg(test)]
+#[cfg(all(feature = "unstable", test))]
 mod tests {
     extern crate test;
     use self::test::Bencher;

--- a/src/cases/titlecase/mod.rs
+++ b/src/cases/titlecase/mod.rs
@@ -72,7 +72,6 @@ fn to_title_from_snake(non_sentence_case_string: String) -> String {
     }
     result.trim().to_string()
 }
-
 /// Determines if a `String` is `Title Case`
 ///
 /// #Examples
@@ -134,4 +133,25 @@ fn to_title_from_snake(non_sentence_case_string: String) -> String {
 /// ```
 pub fn is_title_case(test_string: String) -> bool {
     test_string == to_title_case(test_string.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate test;
+    use self::test::Bencher;
+
+    #[bench]
+    fn bench_title(b: &mut Bencher) {
+        b.iter(|| super::to_title_case("Foo BAR".to_string()));
+    }
+
+    #[bench]
+    fn bench_is_title(b: &mut Bencher) {
+        b.iter(|| super::is_title_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_title_from_snake(b: &mut Bencher) {
+        b.iter(|| super::to_title_from_snake("foo_bar".to_string()));
+    }
 }

--- a/src/cases/titlecase/mod.rs
+++ b/src/cases/titlecase/mod.rs
@@ -1,6 +1,4 @@
 use std::ascii::*;
-use cases::snakecase::to_snake_case;
-
 /// Converts a `String` to `Title Case` `String`
 ///
 /// #Examples
@@ -53,24 +51,27 @@ use cases::snakecase::to_snake_case;
 ///
 /// ```
 pub fn to_title_case(non_title_case_string: String) -> String {
-    to_title_from_snake(to_snake_case(non_title_case_string))
-}
-
-fn to_title_from_snake(non_sentence_case_string: String) -> String {
-    let mut result: String = "".to_string();
-    let mut first_character: bool = true;
-    for character in non_sentence_case_string.chars() {
-        if character.to_string() != "_" && character.to_string() != "-" && !first_character {
-            result = format!("{}{}", result, character.to_ascii_lowercase());
-            first_character = false
-        } else if character.to_string() == "_" || character.to_string() == "-" {
-            first_character = true;
-        } else {
-            result = format!("{} {}", result, character.to_ascii_uppercase());
-            first_character = false;
-        }
-    }
-    result.trim().to_string()
+    let mut new_word: bool = true;
+    let mut last_char: char = ' ';
+    non_title_case_string
+        .chars()
+        .fold("".to_string(), |result, character|
+            if character == '-' || character == '_' || character == ' ' {
+                new_word = true;
+                result
+            } else if new_word || (
+                (last_char.is_lowercase() && character.is_uppercase()) &&
+                (last_char != ' ')
+                ){
+                new_word = false;
+                format!("{} {}", result, character.to_ascii_uppercase())
+                    .trim()
+                    .to_string()
+            } else {
+                last_char = character;
+                format!("{}{}", result, character.to_ascii_lowercase())
+            }
+        )
 }
 /// Determines if a `String` is `Title Case`
 ///
@@ -152,6 +153,6 @@ mod tests {
 
     #[bench]
     fn bench_title_from_snake(b: &mut Bencher) {
-        b.iter(|| super::to_title_from_snake("foo_bar".to_string()));
+        b.iter(|| super::to_title_case("foo_bar".to_string()));
     }
 }

--- a/src/cases/titlecase/mod.rs
+++ b/src/cases/titlecase/mod.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use std::ascii::*;
 /// Converts a `String` to `Title Case` `String`
 ///
@@ -136,7 +137,7 @@ pub fn is_title_case(test_string: String) -> bool {
     test_string == to_title_case(test_string.clone())
 }
 
-#[cfg(test)]
+#[cfg(all(feature = "unstable", test))]
 mod tests {
     extern crate test;
     use self::test::Bencher;

--- a/src/cases/uppercase/mod.rs
+++ b/src/cases/uppercase/mod.rs
@@ -45,7 +45,7 @@ pub fn is_upper_case(test_string: String) -> bool {
     test_string == to_upper_case(test_string.to_owned())
 }
 
-#[cfg(test)]
+#[cfg(all(feature = "unstable", test))]
 mod tests {
     extern crate test;
     use self::test::Bencher;

--- a/src/cases/uppercase/mod.rs
+++ b/src/cases/uppercase/mod.rs
@@ -9,6 +9,7 @@
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
+#[deprecated(since="0.3.2", note="Please use the standard `.to_uppercase()`")]
 pub fn to_upper_case(non_upper_string: String) -> String {
     non_upper_string.chars()
         .flat_map(char::to_uppercase)
@@ -39,7 +40,7 @@ pub fn to_upper_case(non_upper_string: String) -> String {
 ///     assert!(asserted_bool == false);
 ///
 /// ```
-
+#[deprecated(since="0.3.2", note="Please use the standard `.is_uppercase()`")]
 pub fn is_upper_case(test_string: String) -> bool {
     test_string == to_upper_case(test_string.to_owned())
 }

--- a/src/cases/uppercase/mod.rs
+++ b/src/cases/uppercase/mod.rs
@@ -43,3 +43,19 @@ pub fn to_upper_case(non_upper_string: String) -> String {
 pub fn is_upper_case(test_string: String) -> bool {
     test_string == to_upper_case(test_string.to_owned())
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate test;
+    use self::test::Bencher;
+
+    #[bench]
+    fn bench_upper(b: &mut Bencher) {
+        b.iter(|| super::to_upper_case("Foo BAR".to_string()));
+    }
+
+    #[bench]
+    fn bench_is_upper(b: &mut Bencher) {
+        b.iter(|| super::is_upper_case("Foo bar".to_string()));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 // #![deny(warnings)]
 #![feature(test)]
+#![feature(unboxed_closures)]
 
 //! Adds String based inflections for Rust. Snake, kebab, camel,
 //! sentence, class, title, upper, and lower cases as well as ordinalize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 // #![deny(warnings)]
-#![feature(test)]
-#![feature(unboxed_closures)]
+#![cfg_attr(feature = "unstable", feature(test))]
 
 //! Adds String based inflections for Rust. Snake, kebab, camel,
 //! sentence, class, title, upper, and lower cases as well as ordinalize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-#![deny(warnings)]
+// #![deny(warnings)]
+#![feature(test)]
 
 //! Adds String based inflections for Rust. Snake, kebab, camel,
 //! sentence, class, title, upper, and lower cases as well as ordinalize,

--- a/src/numbers/deordinalize/mod.rs
+++ b/src/numbers/deordinalize/mod.rs
@@ -109,7 +109,8 @@ pub fn deordinalize(non_ordinalized_string: String) -> String {
     if non_ordinalized_string.contains('.') {
         non_ordinalized_string
     } else {
-        non_ordinalized_string.trim_right_matches("st")
+        non_ordinalized_string
+            .trim_right_matches("st")
             .trim_right_matches("nd")
             .trim_right_matches("rd")
             .trim_right_matches("th")

--- a/src/numbers/mod.rs
+++ b/src/numbers/mod.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 /// Provides ordinalization of a string.
 ///
 /// Example string "1" becomes "1st"

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 /// Provides demodulize a string.
 ///
 /// Example string `Foo::Bar` becomes `Bar`

--- a/src/string/singularize/mod.rs
+++ b/src/string/singularize/mod.rs
@@ -1,12 +1,6 @@
 use regex::Regex;
 use regex::Captures;
 use string::constants::UNACCONTABLE_WORDS;
-
-const SINGULAR_RULES: [&'static str; 27] = ["ews", "", "um", "sis", "sis", "fe", "", "", "f", "y",
-                                            "eries", "ovie", "", "ouse", "", "", "is", "xis",
-                                            "us", "", "", "ex", "ix", "", "", "", ""];
-
-
 /// Converts a `String` to singularized `String`
 ///
 /// #Examples
@@ -59,151 +53,111 @@ const SINGULAR_RULES: [&'static str; 27] = ["ews", "", "um", "sis", "sis", "fe",
 ///
 /// ```
 ///
+macro_rules! special_cases{
+    ($s:ident, $($singular: expr => $plural:expr), *) => {
+        match &$s[..] {
+            $(
+                $singular => {
+                    return $plural.to_string();
+                },
+            )*
+            _ => ()
+        }
+    }
+}
 pub fn to_singular(non_singular_string: String) -> String {
     if UNACCONTABLE_WORDS.contains(&non_singular_string.as_ref()) {
         non_singular_string
     } else {
-        let safe_out_string: String = non_singular_string.to_string();
-        let maybe_regex_match: Option<String> = singularize_string(non_singular_string);
-        maybe_regex_match.unwrap_or(safe_out_string)
-    }
-}
-
-fn singularize_string(non_singular_string: String) -> Option<String> {
-    let singular_regexes: [Regex; 27] = singular_rules_regexes();
-    for singular_index in 0..singular_regexes.len() {
-        let maybe_match: Option<String> =
-            singularize_string_from_capture_groups_if_match(non_singular_string.to_string(),
-                                                            singular_index);
-
-        if maybe_match.is_some() {
-            return Some(maybe_match.unwrap_or(non_singular_string));
+        special_cases![non_singular_string,
+            "oxen" => "ox",
+            "men" => "man",
+            "women" => "woman",
+            "dice" => "die",
+            "yeses" => "yes",
+            "feet" => "foot",
+            "eaves" => "eave",
+            "geese" => "goose",
+            "teeth" => "tooth",
+            "quizzes" => "quiz"
+        ];
+        for &(ref rule, replace) in RULES.iter().rev() {
+            if let Some(c) = rule.captures(&non_singular_string) {
+                if let Some(c) = c.at(1) {
+                    return format!("{}{}", c, replace);
+                }
+            }
         }
-    }
-    return None;
-}
 
-fn singularize_string_from_capture_groups_if_match(non_singular_string: String,
-                                                   singular_index: usize)
-                                                   -> Option<String> {
-    let singular_regexes: [Regex; 27] = singular_rules_regexes();
-
-    if singular_regexes[singular_index].is_match(&non_singular_string) {
-
-        let cap: Captures = singular_regexes[singular_index]
-            .captures(&non_singular_string)
-            .unwrap();
-
-        Some(singularize_string_from_capture_groups(cap, singular_index))
-    } else {
-        None
+        format!("{}", non_singular_string)
     }
 }
 
-fn singularize_string_from_capture_groups(capture_groups: Captures,
-                                          singular_index: usize)
-                                          -> String {
-    if capture_groups.len() > 2 {
 
-        return format!("{}{}{}",
-                       capture_groups.at(1).unwrap_or(""),
-                       capture_groups.at(2).unwrap_or(""),
-                       SINGULAR_RULES[singular_index]);
-    } else {
-
-        return format!("{}{}",
-                       capture_groups.at(1).unwrap_or(""),
-                       SINGULAR_RULES[singular_index]);
+macro_rules! add_rule{
+    ($r:ident, $rule:expr => $replace:expr) => {
+        $r.push((Regex::new($rule).unwrap(), $replace));
     }
 }
 
-fn singular_rules_regexes() -> [Regex; 27] {
-    [Regex::new(r"(n)ews$").unwrap(),
-     Regex::new(r"(\w*)(o)es$").unwrap(),
-     Regex::new(r"(\w*)([ti])a$").unwrap(),
-     Regex::new(r"((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$").unwrap(),
-     Regex::new(r"(^analy)(sis|ses)$").unwrap(),
-     Regex::new(r"(\w*)([^f])ves$").unwrap(),
-     Regex::new(r"(\w*)(hive)s$").unwrap(),
-     Regex::new(r"(\w*)(tive)s$").unwrap(),
-     Regex::new(r"(\w*)([lr])ves$").unwrap(),
-     Regex::new(r"(\w*)([^aeiouy]|qu)ies$").unwrap(),
-     Regex::new(r"(s)eries$").unwrap(),
-     Regex::new(r"(m)ovies$").unwrap(),
-     Regex::new(r"(\w*)(x|ch|ss|sh)es$").unwrap(),
-     Regex::new(r"(m|l)ice$").unwrap(),
-     Regex::new(r"(bus)(es)?$").unwrap(),
-     Regex::new(r"(shoe)s$").unwrap(),
-     Regex::new(r"(cris|test)(is|es)$").unwrap(),
-     Regex::new(r"^(a)x[ie]s$").unwrap(),
-     Regex::new(r"(octop|vir)(us|i)$").unwrap(),
-     Regex::new(r"(alias|status)(es)?$").unwrap(),
-     Regex::new(r"^(ox)en").unwrap(),
-     Regex::new(r"(vert|ind)ices$").unwrap(),
-     Regex::new(r"(matr)ices$").unwrap(),
-     Regex::new(r"(quiz)zes$").unwrap(),
-     Regex::new(r"(database)s$").unwrap(),
-     Regex::new(r"(\w*)s$").unwrap(),
-     Regex::new(r"(\w*)(ss)$").unwrap()]
+macro_rules! rules{
+    ($r:ident; $($rule:expr => $replace:expr), *) => {
+        $(
+            add_rule!{$r, $rule => $replace}
+        )*
+    }
+}
 
+
+lazy_static!{
+    static ref RULES: Vec<(Regex, &'static str)> = {
+    let mut r = Vec::new();
+    rules![r;
+     r"(n)ews$" => "ews",
+     r"(\w*)(o)es$" => "",
+     r"(\w*)([ti])a$" => "um",
+     r"((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$" => "sis",
+     r"(^analy)(sis|ses)$" => "sis",
+     r"(\w*)([^f])ves$" => "fe",
+     r"(\w*)(hive)s$" => "",
+     r"(\w*)(tive)s$" => "",
+     r"(\w*)([lr])ves$" => "f",
+     r"(\w*)([^aeiouy]|qu)ies$" => "y",
+     r"(s)eries$" => "eries",
+     r"(m)ovies$" => "ovie",
+     r"(\w*)(x|ch|ss|sh)es$" => "",
+     r"(m|l)ice$" => "ouse",
+     r"(bus)(es)?$" => "",
+     r"(shoe)s$" => "",
+     r"(cris|test)(is|es)$" => "is",
+     r"^(a)x[ie]s$" => "xis",
+     r"(octop|vir)(us|i)$" => "us",
+     r"(alias|status)(es)?$" => "",
+     r"^(ox)en" => "",
+     r"(vert|ind)ices$" => "ex",
+     r"(matr)ices$" => "ix",
+     r"(quiz)zes$" => "",
+     r"(database)s$" => "",
+     r"(\w*)s$" => "",
+     r"(\w*)(ss)$" => ""
+         ];
+     r
+    };
 }
 
 #[test]
 fn singularize_string_if_a_regex_will_match() {
-    let expected_string: String = "oxen".to_string();
-    let asserted_string: Option<String> = singularize_string(expected_string);
-
-    assert!(asserted_string.is_some());
+    let expected_string: String = "ox".to_string();
+    let asserted_string: String = to_singular("oxen".to_string());
+    assert!(expected_string == asserted_string);
 
 }
 
 #[test]
 fn singularize_string_returns_none_option_if_no_match() {
     let expected_string: String = "bacon".to_string();
-    let asserted_string: Option<String> = singularize_string(expected_string);
+    let asserted_string: String = to_singular("bacon".to_string());
 
-    assert!(asserted_string.is_none());
-
-}
-
-#[test]
-fn singularize_string_from_capture_groups_if_match_should_return_a_string_if_a_match() {
-    let expected_string: String = "oxen".to_string();
-    let singular_index: usize = 20;
-    let asserted_string: Option<String> =
-        singularize_string_from_capture_groups_if_match(expected_string, singular_index);
-
-    assert!(asserted_string.is_some());
-
-}
-
-#[test]
-fn singularize_string_from_capture_groups_if_match_should_return_an_option_none_if_no_match() {
-    let expected_string: String = "bacon".to_string();
-    let singular_index: usize = 20;
-    let asserted_string: Option<String> =
-        singularize_string_from_capture_groups_if_match(expected_string, singular_index);
-
-    assert!(asserted_string.is_none());
-
-}
-
-#[test]
-fn singularize_string_from_capture_groups_should_return_a_singularized_string() {
-    let expected_string: String = "ox".to_string();
-    let test_string: String = "oxen".to_string();
-    let singular_regexes: [Regex; 27] = singular_rules_regexes();
-    let singular_index: usize = 20;
-    let cap: Captures = singular_regexes[singular_index]
-        .captures(&test_string)
-        .unwrap();
-    let asserted_string: String = singularize_string_from_capture_groups(cap, singular_index);
     assert!(expected_string == asserted_string);
 
-}
-
-#[test]
-fn singular_rules_regexes_should_return_27_regex() {
-    let regexes: [Regex; 27] = singular_rules_regexes();
-    assert!(regexes.len() == 27);
 }

--- a/src/string/singularize/mod.rs
+++ b/src/string/singularize/mod.rs
@@ -1,5 +1,4 @@
 use regex::Regex;
-use regex::Captures;
 use string::constants::UNACCONTABLE_WORDS;
 /// Converts a `String` to singularized `String`
 ///

--- a/src/suffix/mod.rs
+++ b/src/suffix/mod.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 /// Provides foreign key conversion for String.
 ///
 /// Example string `foo` becomes `foo_id`


### PR DESCRIPTION
# What it does:
- Fixes performance issues brought up with #18 and #25 

# Why it does it:
- Performance was lower than the equal ruby implementation

# Related issues:
- #18, #25


## Benchmarks:
```shell
test cases::camelcase::tests::bench_camel0                      ... bench:         139 ns/iter (+/- 40)
test cases::camelcase::tests::bench_camel1                      ... bench:         138 ns/iter (+/- 31)
test cases::camelcase::tests::bench_camel2                      ... bench:         138 ns/iter (+/- 41)
test cases::camelcase::tests::bench_is_camel                    ... bench:         184 ns/iter (+/- 90)
test cases::classcase::tests::bench_class_case                  ... bench:       2,383 ns/iter (+/- 557)
test cases::classcase::tests::bench_class_from_snake            ... bench:       2,393 ns/iter (+/- 1,120)
test cases::classcase::tests::bench_is_class                    ... bench:       2,443 ns/iter (+/- 1,060)
test cases::kebabcase::tests::bench_is_kebab                    ... bench:         182 ns/iter (+/- 60)
test cases::kebabcase::tests::bench_kebab                       ... bench:         161 ns/iter (+/- 98)
test cases::kebabcase::tests::bench_kebab_from_snake            ... bench:         264 ns/iter (+/- 144)
test cases::lowercase::tests::bench_is_lower                    ... bench:         358 ns/iter (+/- 154)
test cases::lowercase::tests::bench_lower                       ... bench:         347 ns/iter (+/- 220)
test cases::screamingsnakecase::tests::bench_is_screaming_snake ... bench:         194 ns/iter (+/- 35)
test cases::screamingsnakecase::tests::bench_screaming_snake    ... bench:         173 ns/iter (+/- 97)
test cases::sentencecase::tests::bench_is_sentence              ... bench:         377 ns/iter (+/- 83)
test cases::sentencecase::tests::bench_sentence                 ... bench:         337 ns/iter (+/- 155)
test cases::sentencecase::tests::bench_sentence_from_snake      ... bench:         370 ns/iter (+/- 176)
test cases::snakecase::tests::bench_is_snake                    ... bench:         191 ns/iter (+/- 98)
test cases::snakecase::tests::bench_snake_from_camel            ... bench:         156 ns/iter (+/- 25)
test cases::snakecase::tests::bench_snake_from_snake            ... bench:         289 ns/iter (+/- 136)
test cases::snakecase::tests::bench_snake_from_title            ... bench:         157 ns/iter (+/- 68)
test cases::tablecase::tests::bench_is_table_case               ... bench:       2,253 ns/iter (+/- 978)
test cases::tablecase::tests::bench_table_case                  ... bench:       2,227 ns/iter (+/- 704)
test cases::titlecase::tests::bench_is_title                    ... bench:         787 ns/iter (+/- 362)
test cases::titlecase::tests::bench_title                       ... bench:         826 ns/iter (+/- 317)
test cases::titlecase::tests::bench_title_from_snake            ... bench:         747 ns/iter (+/- 230)
test cases::uppercase::tests::bench_is_upper                    ... bench:         347 ns/iter (+/- 111)
test cases::uppercase::tests::bench_upper                       ... bench:         328 ns/iter (+/- 42)
```

## OLD Benchmarks:
```shell
test cases::camelcase::tests::bench_camel                                         ... bench:       1,825 ns/iter (+/- 346)
test cases::camelcase::tests::bench_camel_from_sname                              ... bench:       1,223 ns/iter (+/- 289)
test cases::camelcase::tests::bench_is_camel                                      ... bench:      49,416 ns/iter (+/- 593)
test cases::classcase::tests::bench_class_case                                    ... bench: 160,985,376 ns/iter (+/- 5,173,751)
test cases::classcase::tests::bench_class_from_snake                              ... bench: 161,533,425 ns/iter (+/- 4,167,305)
test cases::classcase::tests::bench_is_class                                      ... bench: 161,352,118 ns/iter (+/- 3,793,478)
test cases::kebabcase::tests::bench_is_kebab                                      ... bench:         793 ns/iter (+/- 400)
test cases::kebabcase::tests::bench_kebab                                         ... bench:         752 ns/iter (+/- 310)
test cases::kebabcase::tests::bench_kebab_from_snake                              ... bench:         210 ns/iter (+/- 32)
test cases::lowercase::tests::bench_is_lower                                      ... bench:         340 ns/iter (+/- 86)
test cases::lowercase::tests::bench_lower                                         ... bench:         306 ns/iter (+/- 173)
test cases::screamingsnakecase::tests::bench_is_screaming_snake                   ... bench:         635 ns/iter (+/- 210)
test cases::screamingsnakecase::tests::bench_screaming_snake                      ... bench:         610 ns/iter (+/- 87)
test cases::screamingsnakecase::tests::bench_screaming_snake_from_camel           ... bench:         961 ns/iter (+/- 579)
test cases::screamingsnakecase::tests::bench_screaming_snake_from_class           ... bench:         894 ns/iter (+/- 352)
test cases::screamingsnakecase::tests::bench_screaming_snake_from_kebab           ... bench:         877 ns/iter (+/- 571)
test cases::screamingsnakecase::tests::bench_screaming_snake_from_screaming_snake ... bench:         584 ns/iter (+/- 304)
test cases::screamingsnakecase::tests::bench_screaming_snake_from_sentence        ... bench:       1,123 ns/iter (+/- 630)
test cases::screamingsnakecase::tests::bench_screaming_snake_from_upper_kebab     ... bench:         914 ns/iter (+/- 435)
test cases::sentencecase::tests::bench_is_sentence                                ... bench:       2,714 ns/iter (+/- 796)
test cases::sentencecase::tests::bench_sentence                                   ... bench:       2,678 ns/iter (+/- 1,357)
test cases::sentencecase::tests::bench_sentence_from_snake                        ... bench:       2,100 ns/iter (+/- 1,046)
test cases::snakecase::tests::bench_is_snake                                      ... bench:         626 ns/iter (+/- 191)
test cases::snakecase::tests::bench_snake                                         ... bench:         581 ns/iter (+/- 298)
test cases::snakecase::tests::bench_snake_from_camel                              ... bench:         882 ns/iter (+/- 328)
test cases::snakecase::tests::bench_snake_from_class                              ... bench:         883 ns/iter (+/- 193)
test cases::snakecase::tests::bench_snake_from_kebab                              ... bench:         922 ns/iter (+/- 360)
test cases::snakecase::tests::bench_snake_from_sentence                           ... bench:       1,209 ns/iter (+/- 539)
test cases::snakecase::tests::bench_snake_from_snake                              ... bench:         637 ns/iter (+/- 386)
test cases::snakecase::tests::bench_snake_from_upper_kebab                        ... bench:         876 ns/iter (+/- 488)
test cases::tablecase::tests::bench_is_table_case                                 ... bench:       5,784 ns/iter (+/- 1,129)
test cases::tablecase::tests::bench_table_case                                    ... bench:       5,754 ns/iter (+/- 1,460)
test cases::titlecase::tests::bench_is_title                                      ... bench:       2,847 ns/iter (+/- 1,553)
test cases::titlecase::tests::bench_title                                         ... bench:       2,799 ns/iter (+/- 1,309)
test cases::titlecase::tests::bench_title_from_snake                              ... bench:       2,202 ns/iter (+/- 697)
test cases::uppercase::tests::bench_is_upper                                      ... bench:         357 ns/iter (+/- 55)
test cases::uppercase::tests::bench_upper                                         ... bench:         311 ns/iter (+/- 135)