### PR TITLE
Added pascal case

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,17 @@
 # Thank you!
 
+## Getting started
+- If you don't have rust installed install [rustup](https://www.rustup.rs/)
+- For development with benchmarks run nightly
+  - `rustup toolchain install nightly`
+  - `rustup default nightly`
+
+### Running the tests
+- `cargo test`
+
+### Running the benchmarks
+- `cargo bench --features=unstable`
+
 ## Is this an issues?
 
 - Please ensure you fill out an [issue](https://github.com/whatisinternet/inflector/issues)
@@ -12,7 +24,6 @@
 
 ## Are you submitting code?
 
-- Have all files been run through [rustfmt](https://github.com/rust-lang-nursery/rustfmt)?
 - Have you added doc tests and do they pass?
 - Do all other tests pass?
 - Have you filled out the pull request template?

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Inflector"
-version = "0.3.4"
+version = "0.4.0"
 authors = ["Josh Teeter<joshteeter@gmail.com>"]
 exclude = [".travis.yml", ".gitignore"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Inflector"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Josh Teeter<joshteeter@gmail.com>"]
 exclude = [".travis.yml", ".gitignore"]
 readme = "README.md"
@@ -13,6 +13,8 @@ Adds String based inflections for Rust. Snake, kebab, camel, sentence, class, ti
 """
 keywords = ["string", "case", "camel", "snake", "inflection"]
 
+[features]
+unstable = []
 
 [lib]
 crate_type = ["dylib", "rlib"]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Documentation can be found here at the README or via rust docs below.
 
 ```toml
 [dependencies]
-Inflector = "0.3.3"
+Inflector = "0.4.0"
 ```
 
 ### Compile yourself:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,49 @@
+# 0.4.0
+
+## Fixes:
+
+- Fixes issue where strings like `HTTPParty` becomes `h_t_t_p_party` instead of `http_party` as it should -- Thanks @cmsd2
+
+## New features:
+
+- Adds PascalCase
+
+## Benchmarks:
+```shell
+test cases::camelcase::tests::bench_camel0                      ... bench:         142 ns/iter (+/- 28)
+test cases::camelcase::tests::bench_camel1                      ... bench:         143 ns/iter (+/- 30)
+test cases::camelcase::tests::bench_camel2                      ... bench:         138 ns/iter (+/- 80)
+test cases::camelcase::tests::bench_is_camel                    ... bench:         171 ns/iter (+/- 103)
+test cases::classcase::tests::bench_class_case                  ... bench:       2,369 ns/iter (+/- 658)
+test cases::classcase::tests::bench_class_from_snake            ... bench:       2,378 ns/iter (+/- 914)
+test cases::classcase::tests::bench_is_class                    ... bench:       2,541 ns/iter (+/- 294)
+test cases::kebabcase::tests::bench_is_kebab                    ... bench:         180 ns/iter (+/- 35)
+test cases::kebabcase::tests::bench_kebab                       ... bench:         156 ns/iter (+/- 91)
+test cases::kebabcase::tests::bench_kebab_from_snake            ... bench:         248 ns/iter (+/- 143)
+test cases::lowercase::tests::bench_is_lower                    ... bench:         340 ns/iter (+/- 91)
+test cases::lowercase::tests::bench_lower                       ... bench:         301 ns/iter (+/- 124)
+test cases::pascalcase::tests::bench_is_pascal                  ... bench:         163 ns/iter (+/- 65)
+test cases::pascalcase::tests::bench_pascal0                    ... bench:         140 ns/iter (+/- 78)
+test cases::pascalcase::tests::bench_pascal1                    ... bench:         140 ns/iter (+/- 40)
+test cases::pascalcase::tests::bench_pascal2                    ... bench:         138 ns/iter (+/- 105)
+test cases::screamingsnakecase::tests::bench_is_screaming_snake ... bench:         193 ns/iter (+/- 27)
+test cases::screamingsnakecase::tests::bench_screaming_snake    ... bench:         161 ns/iter (+/- 84)
+test cases::sentencecase::tests::bench_is_sentence              ... bench:         394 ns/iter (+/- 85)
+test cases::sentencecase::tests::bench_sentence                 ... bench:         365 ns/iter (+/- 186)
+test cases::sentencecase::tests::bench_sentence_from_snake      ... bench:         333 ns/iter (+/- 178)
+test cases::snakecase::tests::bench_is_snake                    ... bench:         190 ns/iter (+/- 74)
+test cases::snakecase::tests::bench_snake_from_camel            ... bench:         155 ns/iter (+/- 44)
+test cases::snakecase::tests::bench_snake_from_snake            ... bench:         280 ns/iter (+/- 161)
+test cases::snakecase::tests::bench_snake_from_title            ... bench:         156 ns/iter (+/- 31)
+test cases::tablecase::tests::bench_is_table_case               ... bench:       2,388 ns/iter (+/- 431)
+test cases::tablecase::tests::bench_table_case                  ... bench:       2,240 ns/iter (+/- 446)
+test cases::titlecase::tests::bench_is_title                    ... bench:         786 ns/iter (+/- 135)
+test cases::titlecase::tests::bench_title                       ... bench:         826 ns/iter (+/- 278)
+test cases::titlecase::tests::bench_title_from_snake            ... bench:         723 ns/iter (+/- 256)
+test cases::uppercase::tests::bench_is_upper                    ... bench:         351 ns/iter (+/- 85)
+test cases::uppercase::tests::bench_upper                       ... bench:         332 ns/iter (+/- 48)
+```
+
 # 0.3.3
 
 ## Fixes:

--- a/src/cases/mod.rs
+++ b/src/cases/mod.rs
@@ -48,4 +48,9 @@ pub mod uppercase;
 /// Example string `LOWERCASE`
 pub mod lowercase;
 
+/// Provides conversion to pascal case strings.
+///
+/// Example string `PascalCase`
+pub mod pascalcase;
+
 mod case;

--- a/src/cases/pascalcase/mod.rs
+++ b/src/cases/pascalcase/mod.rs
@@ -1,0 +1,221 @@
+#![deny(warnings)]
+use std::ascii::*;
+/// Converts a `String` to pascalCase `String`
+///
+/// #Examples
+/// ```
+///     use inflector::cases::pascalcase::to_pascal_case;
+///     let mock_string: String = "fooBar".to_string();
+///     let expected_string: String = "FooBar".to_string();
+///     let asserted_string: String = to_pascal_case(mock_string);
+///     assert!(asserted_string == expected_string);
+///
+/// ```
+/// ```
+///     use inflector::cases::pascalcase::to_pascal_case;
+///     let mock_string: String = "FOO_BAR".to_string();
+///     let expected_string: String = "FooBar".to_string();
+///     let asserted_string: String = to_pascal_case(mock_string);
+///     assert!(asserted_string == expected_string);
+///
+/// ```
+/// ```
+///     use inflector::cases::pascalcase::to_pascal_case;
+///     let mock_string: String = "Foo Bar".to_string();
+///     let expected_string: String = "FooBar".to_string();
+///     let asserted_string: String = to_pascal_case(mock_string);
+///     assert!(asserted_string == expected_string);
+///
+/// ```
+/// ```
+///     use inflector::cases::pascalcase::to_pascal_case;
+///     let mock_string: String = "foo_bar".to_string();
+///     let expected_string: String = "FooBar".to_string();
+///     let asserted_string: String = to_pascal_case(mock_string);
+///     assert!(asserted_string == expected_string);
+///
+/// ```
+/// ```
+///     use inflector::cases::pascalcase::to_pascal_case;
+///     let mock_string: String = "Foo bar".to_string();
+///     let expected_string: String = "FooBar".to_string();
+///     let asserted_string: String = to_pascal_case(mock_string);
+///     assert!(asserted_string == expected_string);
+///
+/// ```
+/// ```
+///     use inflector::cases::pascalcase::to_pascal_case;
+///     let mock_string: String = "foo-bar".to_string();
+///     let expected_string: String = "FooBar".to_string();
+///     let asserted_string: String = to_pascal_case(mock_string);
+///     assert!(asserted_string == expected_string);
+///
+/// ```
+/// ```
+///     use inflector::cases::pascalcase::to_pascal_case;
+///     let mock_string: String = "FooBar".to_string();
+///     let expected_string: String = "FooBar".to_string();
+///     let asserted_string: String = to_pascal_case(mock_string);
+///     assert!(asserted_string == expected_string);
+///
+/// ```
+/// ```
+///     use inflector::cases::pascalcase::to_pascal_case;
+///     let mock_string: String = "FooBar3".to_string();
+///     let expected_string: String = "FooBar3".to_string();
+///     let asserted_string: String = to_pascal_case(mock_string);
+///     assert!(asserted_string == expected_string);
+///
+/// ```
+pub fn to_pascal_case(non_pascalized_string: String) -> String {
+    let mut new_word: bool = true;
+    let mut last_char: char = ' ';
+    non_pascalized_string
+        .chars()
+        .fold("".to_string(), |mut result, character|
+            if character == '-' || character == '_' || character == ' ' {
+                new_word = true;
+                result
+            } else if character.is_numeric() {
+                new_word = true;
+                result.push(character);
+                result
+            } else if new_word || (
+                (last_char.is_lowercase() && character.is_uppercase()) &&
+                (last_char != ' ')
+                ){
+                new_word = false;
+                result.push(character.to_ascii_uppercase());
+                result
+            } else {
+                last_char = character;
+                result.push(character.to_ascii_lowercase());
+                result
+            }
+        )
+}
+
+/// Determines if a `String` is pascalCase bool``
+///
+/// #Examples
+/// ```
+///     use inflector::cases::pascalcase::is_pascal_case;
+///     let mock_string: String = "Foo".to_string();
+///     let asserted_bool: bool = is_pascal_case(mock_string);
+///     assert!(asserted_bool == true);
+///
+///
+/// ```
+/// ```
+///     use inflector::cases::pascalcase::is_pascal_case;
+///     let mock_string: String = "foo".to_string();
+///     let asserted_bool: bool = is_pascal_case(mock_string);
+///     assert!(asserted_bool == false);
+///
+///
+/// ```
+/// ```
+///     use inflector::cases::pascalcase::is_pascal_case;
+///     let mock_string: String = "foo-bar-string-that-is-really-really-long".to_string();
+///     let asserted_bool: bool = is_pascal_case(mock_string);
+///     assert!(asserted_bool == false);
+///
+///
+/// ```
+/// ```
+///     use inflector::cases::pascalcase::is_pascal_case;
+///     let mock_string: String = "FooBarIsAReallyReallyLongString".to_string();
+///     let asserted_bool: bool = is_pascal_case(mock_string);
+///     assert!(asserted_bool == true);
+///
+///
+/// ```
+/// ```
+///     use inflector::cases::pascalcase::is_pascal_case;
+///     let mock_string: String = "FooBarIsAReallyReally3LongString".to_string();
+///     let asserted_bool: bool = is_pascal_case(mock_string);
+///     assert!(asserted_bool == true);
+///
+///
+/// ```
+/// ```
+///     use inflector::cases::pascalcase::is_pascal_case;
+///     let mock_string: String = "FooBarIsAReallyReallyLongString".to_string();
+///     let asserted_bool: bool = is_pascal_case(mock_string);
+///     assert!(asserted_bool == true);
+///
+///
+/// ```
+/// ```
+///     use inflector::cases::pascalcase::is_pascal_case;
+///     let mock_string: String = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG".to_string();
+///     let asserted_bool: bool = is_pascal_case(mock_string);
+///     assert!(asserted_bool == false);
+///
+///
+/// ```
+/// ```
+///     use inflector::cases::pascalcase::is_pascal_case;
+///     let mock_string: String = "foo_bar_string_that_is_really_really_long".to_string();
+///     let asserted_bool: bool = is_pascal_case(mock_string);
+///     assert!(asserted_bool == false);
+///
+///
+/// ```
+/// ```
+///     use inflector::cases::pascalcase::is_pascal_case;
+///     let mock_string: String = "Foo bar string that is really really long".to_string();
+///     let asserted_bool: bool = is_pascal_case(mock_string);
+///     assert!(asserted_bool == false);
+///
+///
+/// ```
+/// ```
+///     use inflector::cases::pascalcase::is_pascal_case;
+///     let mock_string: String = "Foo Bar Is A Really Really Long String".to_string();
+///     let asserted_bool: bool = is_pascal_case(mock_string);
+///     assert!(asserted_bool == false);
+/// ```
+pub fn is_pascal_case(test_string: String) -> bool {
+    to_pascal_case(test_string.clone()) == test_string
+}
+
+#[cfg(all(feature = "unstable", test))]
+mod tests {
+    extern crate test;
+    use self::test::Bencher;
+
+    #[bench]
+    fn bench_pascal0(b: &mut Bencher) {
+        b.iter(|| {
+            let test_string = "Foo bar".to_string();
+            super::to_pascal_case(test_string)
+        });
+    }
+
+    #[bench]
+    fn bench_pascal1(b: &mut Bencher) {
+        b.iter(|| {
+            let test_string = "foo_bar".to_string();
+            super::to_pascal_case(test_string)
+        }
+        );
+    }
+
+    #[bench]
+    fn bench_pascal2(b: &mut Bencher) {
+        b.iter(|| {
+            let test_string = "fooBar".to_string();
+            super::to_pascal_case(test_string)
+        });
+    }
+
+    #[bench]
+    fn bench_is_pascal(b: &mut Bencher) {
+        b.iter(|| {
+            let test_string: String  = "Foo bar".to_string();
+            super::is_pascal_case(test_string)
+        }
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ extern crate lazy_static;
 /// - Sentence case
 /// - Snake case
 /// - Upper case
+/// - Pascal case
 pub mod cases;
 /// Provides number inflections
 /// - Ordinalize
@@ -46,6 +47,9 @@ use cases::classcase::is_class_case;
 
 use cases::camelcase::to_camel_case;
 use cases::camelcase::is_camel_case;
+
+use cases::pascalcase::to_pascal_case;
+use cases::pascalcase::is_pascal_case;
 
 use cases::snakecase::to_snake_case;
 use cases::snakecase::is_snake_case;
@@ -89,6 +93,9 @@ pub trait Inflector {
 
     fn to_camel_case(&self) -> String;
     fn is_camel_case(&self) -> bool;
+
+    fn to_pascal_case(&self) -> String;
+    fn is_pascal_case(&self) -> bool;
 
     fn to_table_case(&self) -> String;
     fn is_table_case(&self) -> bool;
@@ -139,6 +146,12 @@ impl<'c> Inflector for String {
     }
     fn is_camel_case(&self) -> bool {
         is_camel_case(self.to_string())
+    }
+    fn to_pascal_case(&self) -> String {
+        to_pascal_case(self.to_string())
+    }
+    fn is_pascal_case(&self) -> bool {
+        is_pascal_case(self.to_string())
     }
     fn to_table_case(&self) -> String {
         to_table_case(self.to_string())
@@ -226,6 +239,12 @@ impl<'c> Inflector for str {
     }
     fn is_camel_case(&self) -> bool {
         is_camel_case(self.to_string())
+    }
+    fn to_pascal_case(&self) -> String {
+        to_pascal_case(self.to_string())
+    }
+    fn is_pascal_case(&self) -> bool {
+        is_pascal_case(self.to_string())
     }
     fn to_table_case(&self) -> String {
         to_table_case(self.to_string())


### PR DESCRIPTION
# What it does:
- Adds `PascalCase` support

# Why it does it:
- Class case does more than what's expected for those expecting "upper camel case"


# Related issues:
#26



