### PR TITLE
treat runs of uppercase letters as one word except for the last letter

### DIFF
--- a/src/cases/case/mod.rs
+++ b/src/cases/case/mod.rs
@@ -56,46 +56,35 @@ fn to_snake_like_from_camel_or_class(
     replace_with: &str,
     case: &str
     ) -> String {
-    let mut prev_character_was_ucase: bool = false;
-    let mut fragment: String = String::new();
-    let mut result: Vec<String> = vec![];
-
-    for character in convertable_string.chars() {
-        let character_is_ucase = character == character.to_ascii_uppercase();
-
-        if fragment.len() != 0 {
-            if character_is_ucase && !prev_character_was_ucase {
-                result.push(fragment);
-                fragment = String::new();
-            } else if !character_is_ucase && prev_character_was_ucase {
-                let count = fragment.chars().count();
-
-                // last uppercase letter in a run of uppercase 
-                // letters is the start of a new capitalised word:
-
-                let ucase_run: String = fragment.chars().take(count - 1).collect();
-                let new_fragment: String = fragment.chars().skip(count - 1).collect();
-
-                if ucase_run.len() != 0 {
-                    result.push(ucase_run);
-                }
-
-                fragment = new_fragment;
-            }
-        }
-
-        if case == "lower" {
-            fragment.push(character.to_ascii_lowercase());
-        } else {
-            fragment.push(character.to_ascii_uppercase());
-        }
-
-        prev_character_was_ucase = character_is_ucase;
-    }
-
-    if fragment.len() != 0 {
-        result.push(fragment);
-    }
-
-    result.join(&replace_with.chars().nth(0).unwrap_or('_').to_string())
+        let mut first_character: bool = true;
+    convertable_string
+        .chars()
+        .enumerate()
+        .fold("".to_string(), |mut acc, char_with_index|
+              if char_with_index.1 == char_with_index.1.to_ascii_uppercase() &&
+                  !first_character &&
+                  (convertable_string.chars().nth(char_with_index.0 + 1).unwrap_or('A').is_lowercase() ||
+                  convertable_string.chars().nth(char_with_index.0 - 1).unwrap_or('A').is_lowercase()
+                  )
+                  {
+                      if case == "lower" {
+                          acc.push(replace_with.chars().nth(0).unwrap_or('_'));
+                          acc.push(char_with_index.1.to_ascii_lowercase());
+                          acc
+                      } else {
+                          acc.push(replace_with.chars().nth(0).unwrap_or('_'));
+                          acc.push(char_with_index.1.to_ascii_uppercase());
+                          acc
+                      }
+              } else {
+                    first_character = false;
+                    if case == "lower" {
+                        acc.push(char_with_index.1.to_ascii_lowercase());
+                        acc
+                    } else {
+                        acc.push(char_with_index.1.to_ascii_uppercase());
+                        acc
+                    }
+              }
+        )
 }

--- a/src/cases/case/mod.rs
+++ b/src/cases/case/mod.rs
@@ -56,29 +56,46 @@ fn to_snake_like_from_camel_or_class(
     replace_with: &str,
     case: &str
     ) -> String {
-    let mut first_character: bool = true;
-    convertable_string
-        .chars()
-        .fold("".to_string(), |mut acc, character|
-              if character == character.to_ascii_uppercase() && !first_character {
-                  if case == "lower" {
-                    acc.push(replace_with.chars().nth(0).unwrap_or('_'));
-                    acc.push(character.to_ascii_lowercase());
-                    acc
-                  } else {
-                    acc.push(replace_with.chars().nth(0).unwrap_or('_'));
-                    acc.push(character.to_ascii_uppercase());
-                    acc
-                  }
-              } else {
-                  first_character = false;
-                  if case == "lower" {
-                    acc.push(character.to_ascii_lowercase());
-                    acc
-                  } else {
-                    acc.push(character.to_ascii_uppercase());
-                    acc
-                  }
-              }
-        )
+    let mut prev_character_was_ucase: bool = false;
+    let mut fragment: String = String::new();
+    let mut result: Vec<String> = vec![];
+
+    for character in convertable_string.chars() {
+        let character_is_ucase = character == character.to_ascii_uppercase();
+
+        if fragment.len() != 0 {
+            if character_is_ucase && !prev_character_was_ucase {
+                result.push(fragment);
+                fragment = String::new();
+            } else if !character_is_ucase && prev_character_was_ucase {
+                let count = fragment.chars().count();
+
+                // last uppercase letter in a run of uppercase 
+                // letters is the start of a new capitalised word:
+
+                let ucase_run: String = fragment.chars().take(count - 1).collect();
+                let new_fragment: String = fragment.chars().skip(count - 1).collect();
+
+                if ucase_run.len() != 0 {
+                    result.push(ucase_run);
+                }
+
+                fragment = new_fragment;
+            }
+        }
+
+        if case == "lower" {
+            fragment.push(character.to_ascii_lowercase());
+        } else {
+            fragment.push(character.to_ascii_uppercase());
+        }
+
+        prev_character_was_ucase = character_is_ucase;
+    }
+
+    if fragment.len() != 0 {
+        result.push(fragment);
+    }
+
+    result.join(&replace_with.chars().nth(0).unwrap_or('_').to_string())
 }

--- a/src/cases/snakecase/mod.rs
+++ b/src/cases/snakecase/mod.rs
@@ -21,6 +21,14 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::to_snake_case;
+///     let mock_string: String = "HTTPFooBar".to_string();
+///     let expected_string: String = "http_foo_bar".to_string();
+///     let asserted_string: String = to_snake_case(mock_string);
+///     assert!(asserted_string == expected_string);
+///
+/// ```
+/// ```
+///     use inflector::cases::snakecase::to_snake_case;
 ///     let mock_string: String = "Foo bar".to_string();
 ///     let expected_string: String = "foo_bar".to_string();
 ///     let asserted_string: String = to_snake_case(mock_string);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -187,6 +187,16 @@ fn str_trait_to_snake_case() {
 }
 
 #[test]
+fn str_trait_to_snake_case_abbrev() {
+    assert_eq!("TheTLAFactory".to_snake_case(), "the_tla_factory".to_string());
+}
+
+#[test]
+fn str_trait_to_snake_case_abbrev_two() {
+    assert_eq!("theTLAFactory".to_snake_case(), "the_tla_factory".to_string());
+}
+
+#[test]
 fn str_trait_is_snake_case() {
     assert_eq!("foo_foo".is_snake_case(), true);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -197,6 +197,11 @@ fn str_trait_to_snake_case_abbrev_two() {
 }
 
 #[test]
+fn str_trait_to_snake_case_abbrev_three() {
+    assert_eq!("theTLAForHTTP".to_snake_case(), "the_tla_for_http".to_string());
+}
+
+#[test]
 fn str_trait_is_snake_case() {
     assert_eq!("foo_foo".is_snake_case(), true);
 }


### PR DESCRIPTION
keeps runs of uppercase letters together when converting to snake case
e.g. HTTPListener becomes http_listener instead of h_t_t_p_listener

Assuming that runs of uppercase letters are part of an abbreviation is probably the most natural interpretation.

Related issue:
[https://github.com/rusoto/rusoto/pull/235](https://github.com/rusoto/rusoto/pull/235)