### PR TITLE
Train-Case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ matrix:
   allow_failures:
     - rust: nightly
 
-# Do benchmark on Travis.
+# Do benchmark on Travis. #
 script: cargo bench --features=unstable

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,3 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
-
-# Do benchmark on Travis. #
-script: cargo bench --features=unstable

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+
+# Do benchmark on Travis.
+script: cargo bench --features=unstable

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,14 @@
 # What it does:
 
+Train-Case: Converts strings to Train-Case.
+(Like kebab-case but each word is also capitalized).
 
 # Why it does it:
 
+I needed Train-Case in a program and rather than roll out 
+my own library wanted to contribute to this existing
+inflection library.
 
 # Related issues:
 
-
+None.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,7 @@
 # What it does:
 
-Train-Case: Converts strings to Train-Case.
-(Like kebab-case but each word is also capitalized).
 
 # Why it does it:
 
-I needed Train-Case in a program and rather than roll out 
-my own library wanted to contribute to this existing
-inflection library.
 
 # Related issues:
-
-None.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Build Status](https://travis-ci.org/whatisinternet/inflector.svg?branch=master)](https://travis-ci.org/whatisinternet/inflector) [![Crates.io](https://img.shields.io/crates/v/inflector.svg)](https://crates.io/crates/inflector)
 
-Adds String based inflections for Rust. Snake, kebab, camel,
+Adds String based inflections for Rust. Snake, kebab, train, camel,
 sentence, class, title, upper, and lower cases as well as ordinalize,
 deordinalize, demodulize, deconstantize, foreign key, table case, and pluralize/singularize are supported as both traits and pure functions
 acting on String types.
@@ -74,6 +74,9 @@ extern crate inflector;
 // use inflector::cases::kebabcase::to_kebab_case;
 // use inflector::cases::kebabcase::is_kebab_case;
 
+// use inflector::cases::traincase::to_train_case;
+// use inflector::cases::traincase::is_train_case;
+
 // use inflector::cases::sentencecase::to_sentence_case;
 // use inflector::cases::sentencecase::is_sentence_case;
 
@@ -137,6 +140,10 @@ to_snake_case(String) -> String
 
 ```rust
 to_kebab_case(String) -> String
+```
+
+```rust
+to_train_case(String) -> String
 ```
 
 ```rust
@@ -209,6 +216,10 @@ is_snake_case(String) -> bool
 
 ```rust
 is_kebab_case(String) -> bool
+```
+
+```rust
+is_train_case(String) -> bool
 ```
 
 ```rust

--- a/src/cases/mod.rs
+++ b/src/cases/mod.rs
@@ -23,6 +23,11 @@ pub mod screamingsnakecase;
 /// Example string `kebab-case`
 pub mod kebabcase;
 
+/// Provides conversion to and detection of train case strings.
+///
+/// Example string `Train-Case`
+pub mod traincase;
+
 /// Provides conversion to and detection of sentence case strings.
 ///
 /// Example string `Sentence case`

--- a/src/cases/traincase/mod.rs
+++ b/src/cases/traincase/mod.rs
@@ -132,7 +132,7 @@ pub fn to_train_case(non_train_case_string: String) -> String {
     let mut new_word: bool = true;
     let mut first_word: bool = true;
     let mut last_char: char = ' ';
-    let r = non_train_case_string
+    non_train_case_string
         .chars()
         .fold("".to_string(), |mut result, character|
             if character == '-' || character == '_' || character == ' ' {

--- a/src/cases/traincase/mod.rs
+++ b/src/cases/traincase/mod.rs
@@ -1,0 +1,161 @@
+#![deny(warnings)]
+use cases::case::*;
+/// Determines if a `String` is `Train-Case`
+///
+/// #Examples
+/// ```
+///     use inflector::cases::traincase::is_train_case;
+///     let mock_string: String = "Foo-Bar-String-That-Is-Really-Really-Long".to_string();
+///     let asserted_bool: bool = is_train_case(mock_string);
+///     assert!(asserted_bool == true);
+///
+/// ```
+///
+/// ```
+///     use inflector::cases::traincase::is_train_case;
+///     let mock_string: String = "foo-bar-string-that-is-really-really-long".to_string();
+///     let asserted_bool: bool = is_train_case(mock_string);
+///     assert!(asserted_bool == false);
+///
+/// ```
+///
+/// ```
+///     use inflector::cases::traincase::is_train_case;
+///     let mock_string: String = "FooBarIsAReallyReallyLongString".to_string();
+///     let asserted_bool: bool = is_train_case(mock_string);
+///     assert!(asserted_bool == false);
+///
+/// ```
+///
+/// ```
+///     use inflector::cases::traincase::is_train_case;
+///     let mock_string: String = "fooBarIsAReallyReallyLongString".to_string();
+///     let asserted_bool: bool = is_train_case(mock_string);
+///     assert!(asserted_bool == false);
+///
+/// ```
+///
+/// ```
+///     use inflector::cases::traincase::is_train_case;
+///     let mock_string: String = "foo_bar_string_that_is_really_really_long".to_string();
+///     let asserted_bool: bool = is_train_case(mock_string);
+///     assert!(asserted_bool == false);
+///
+/// ```
+///
+/// ```
+///     use inflector::cases::traincase::is_train_case;
+///     let mock_string: String = "Foo bar string that is really really long".to_string();
+///     let asserted_bool: bool = is_train_case(mock_string);
+///     assert!(asserted_bool == false);
+///
+/// ```
+///
+/// ```
+///     use inflector::cases::traincase::is_train_case;
+///     let mock_string: String = "Foo Bar Is A Really Really Long String".to_string();
+///     let asserted_bool: bool = is_train_case(mock_string);
+///     assert!(asserted_bool == false);
+///
+/// ```
+pub fn is_train_case(test_string: String) -> bool {
+    test_string == to_train_case(test_string.clone())
+}
+
+
+/// Converts a `String` to `Train-Case` `String`
+///
+/// #Examples
+/// ```
+///     use inflector::cases::traincase::to_train_case;
+///     let mock_string: String = "foo-bar".to_string();
+///     let expected_string: String = "Foo-Bar".to_string();
+///     let asserted_string: String = to_train_case(mock_string);
+///     assert!(asserted_string == expected_string);
+///
+/// ```
+///
+/// ```
+///     use inflector::cases::traincase::to_train_case;
+///     let mock_string: String = "FOO_BAR".to_string();
+///     let expected_string: String = "Foo-Bar".to_string();
+///     let asserted_string: String = to_train_case(mock_string);
+///     assert!(asserted_string == expected_string);
+///
+/// ```
+///
+/// ```
+///     use inflector::cases::traincase::to_train_case;
+///     let mock_string: String = "foo_bar".to_string();
+///     let expected_string: String = "Foo-Bar".to_string();
+///     let asserted_string: String = to_train_case(mock_string);
+///     assert!(asserted_string == expected_string);
+///
+/// ```
+///
+/// ```
+///     use inflector::cases::traincase::to_train_case;
+///     let mock_string: String = "Foo Bar".to_string();
+///     let expected_string: String = "Foo-Bar".to_string();
+///     let asserted_string: String = to_train_case(mock_string);
+///     assert!(asserted_string == expected_string);
+///
+/// ```
+///
+/// ```
+///     use inflector::cases::traincase::to_train_case;
+///     let mock_string: String = "Foo bar".to_string();
+///     let expected_string: String = "Foo-Bar".to_string();
+///     let asserted_string: String = to_train_case(mock_string);
+///     assert!(asserted_string == expected_string);
+///
+/// ```
+///
+/// ```
+///     use inflector::cases::traincase::to_train_case;
+///     let mock_string: String = "FooBar".to_string();
+///     let expected_string: String = "Foo-Bar".to_string();
+///     let asserted_string: String = to_train_case(mock_string);
+///     assert!(asserted_string == expected_string);
+///
+/// ```
+///
+/// ```
+///     use inflector::cases::traincase::to_train_case;
+///     let mock_string: String = "fooBar".to_string();
+///     let expected_string: String = "Foo-Bar".to_string();
+///     let asserted_string: String = to_train_case(mock_string);
+///     assert!(asserted_string == expected_string);
+///
+/// ```
+pub fn to_train_case(non_train_case_string: String) -> String {
+    let kebab_case_string = to_case_snake_like(non_train_case_string, "-", "lower");
+    let split = kebab_case_string.split("-");
+    let mut train_case_string = Vec::new();
+    let kebab_case_parts: Vec<&str> = split.collect();
+    for c in kebab_case_parts {
+        train_case_string.push(format!("{}{}", &c[0..1].to_uppercase(), &c[1..c.len()]));
+    }
+    train_case_string.join("-")
+}
+
+#[cfg(all(feature = "unstable", test))]
+mod tests {
+    extern crate test;
+    use self::test::Bencher;
+
+    #[bench]
+    fn bench_train(b: &mut Bencher) {
+        b.iter(|| super::to_train_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_is_train(b: &mut Bencher) {
+        b.iter(|| super::is_train_case("Foo bar".to_string()));
+    }
+
+    #[bench]
+    fn bench_train_from_snake(b: &mut Bencher) {
+        b.iter(|| super::to_train_case("test_test_test".to_string()));
+    }
+}

--- a/src/cases/traincase/mod.rs
+++ b/src/cases/traincase/mod.rs
@@ -130,6 +130,7 @@ pub fn is_train_case(test_string: String) -> bool {
 /// ```
 pub fn to_train_case(non_train_case_string: String) -> String {
     let mut new_word: bool = true;
+    let mut first_word: bool = true;
     let mut last_char: char = ' ';
     let r = non_train_case_string
         .chars()
@@ -146,7 +147,10 @@ pub fn to_train_case(non_train_case_string: String) -> String {
                 (last_char != ' ')
                 ){
                 new_word = false;
-                result.push('-');
+                if !first_word {
+                    result.push('-');
+                }
+                first_word = false;
                 result.push(character.to_ascii_uppercase());
                 result
             } else {
@@ -154,8 +158,7 @@ pub fn to_train_case(non_train_case_string: String) -> String {
                 result.push(character.to_ascii_lowercase());
                 result
             }
-        );
-        r[1..r.len()].to_owned()
+        )
 }
 
 #[cfg(all(feature = "unstable", test))]

--- a/src/cases/traincase/mod.rs
+++ b/src/cases/traincase/mod.rs
@@ -1,5 +1,5 @@
 #![deny(warnings)]
-use cases::case::*;
+use std::ascii::*;
 /// Determines if a `String` is `Train-Case`
 ///
 /// #Examples
@@ -129,14 +129,33 @@ pub fn is_train_case(test_string: String) -> bool {
 ///
 /// ```
 pub fn to_train_case(non_train_case_string: String) -> String {
-    let kebab_case_string = to_case_snake_like(non_train_case_string, "-", "lower");
-    let split = kebab_case_string.split("-");
-    let mut train_case_string = Vec::new();
-    let kebab_case_parts: Vec<&str> = split.collect();
-    for c in kebab_case_parts {
-        train_case_string.push(format!("{}{}", &c[0..1].to_uppercase(), &c[1..c.len()]));
-    }
-    train_case_string.join("-")
+    let mut new_word: bool = true;
+    let mut last_char: char = ' ';
+    let r = non_train_case_string
+        .chars()
+        .fold("".to_string(), |mut result, character|
+            if character == '-' || character == '_' || character == ' ' {
+                new_word = true;
+                result
+            } else if character.is_numeric() {
+                new_word = true;
+                result.push(character);
+                result
+            } else if new_word || (
+                (last_char.is_lowercase() && character.is_uppercase()) &&
+                (last_char != ' ')
+                ){
+                new_word = false;
+                result.push('-');
+                result.push(character.to_ascii_uppercase());
+                result
+            } else {
+                last_char = character;
+                result.push(character.to_ascii_lowercase());
+                result
+            }
+        );
+        r[1..r.len()].to_owned()
 }
 
 #[cfg(all(feature = "unstable", test))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // #![deny(warnings)]
 #![cfg_attr(feature = "unstable", feature(test))]
 
-//! Adds String based inflections for Rust. Snake, kebab, camel,
+//! Adds String based inflections for Rust. Snake, kebab, train, camel,
 //! sentence, class, title, upper, and lower cases as well as ordinalize,
 //! deordinalize, demodulize, deconstantize, and foreign key are supported as
 //! both traits and pure functions acting on String types.
@@ -19,6 +19,7 @@ extern crate lazy_static;
 /// - Camel case
 /// - Class case
 /// - Kebab case
+/// - Train case
 /// - Lower case
 /// - Screaming snake case
 /// - Table case
@@ -59,6 +60,9 @@ use cases::screamingsnakecase::is_screaming_snake_case;
 
 use cases::kebabcase::to_kebab_case;
 use cases::kebabcase::is_kebab_case;
+
+use cases::traincase::to_train_case;
+use cases::traincase::is_train_case;
 
 use cases::sentencecase::to_sentence_case;
 use cases::sentencecase::is_sentence_case;
@@ -108,6 +112,9 @@ pub trait Inflector {
 
     fn to_kebab_case(&self) -> String;
     fn is_kebab_case(&self) -> bool;
+
+    fn to_train_case(&self) -> String;
+    fn is_train_case(&self) -> bool;
 
     fn to_sentence_case(&self) -> String;
     fn is_sentence_case(&self) -> bool;
@@ -176,6 +183,12 @@ impl<'c> Inflector for String {
     }
     fn is_kebab_case(&self) -> bool {
         is_kebab_case(self.to_string())
+    }
+    fn to_train_case(&self) -> String {
+        to_train_case(self.to_string())
+    }
+    fn is_train_case(&self) -> bool {
+        is_train_case(self.to_string())
     }
     fn to_sentence_case(&self) -> String {
         to_sentence_case(self.to_string())
@@ -269,6 +282,12 @@ impl<'c> Inflector for str {
     }
     fn is_kebab_case(&self) -> bool {
         is_kebab_case(self.to_string())
+    }
+    fn to_train_case(&self) -> String {
+        to_train_case(self.to_string())
+    }
+    fn is_train_case(&self) -> bool {
+        is_train_case(self.to_string())
     }
     fn to_sentence_case(&self) -> String {
         to_sentence_case(self.to_string())

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -62,6 +62,16 @@ fn string_trait_is_kebab_case() {
 }
 
 #[test]
+fn string_trait_to_train_case() {
+    assert_eq!("FooFoo".to_string().to_train_case(), "Foo-Foo".to_string());
+}
+
+#[test]
+fn string_trait_is_train_case() {
+    assert_eq!("Foo-Foo".to_string().is_train_case(), true);
+}
+
+#[test]
 fn string_trait_to_sentence_case() {
     assert_eq!("fooFoo".to_string().to_sentence_case(), "Foo foo".to_string());
 }
@@ -214,6 +224,16 @@ fn str_trait_to_kebab_case() {
 #[test]
 fn str_trait_is_kebab_case() {
     assert_eq!("foo-foo".is_kebab_case(), true);
+}
+
+#[test]
+fn str_trait_to_train_case() {
+	assert_eq!("fooFoo".to_train_case(), "Foo-Foo".to_string());
+}
+
+#[test]
+fn str_trait_is_train_case() {
+	assert_eq!("Foo-Foo".is_train_case(), true);
 }
 
 #[test]


### PR DESCRIPTION
# What it does:

Train-Case: Converts strings to Train-Case.
(Like kebab-case but each word is also capitalized).

# Why it does it:

I needed Train-Case in a program and rather than roll out 
my own library wanted to contribute to this existing
inflection library.

# Related issues:

None.


