### PR TITLE
Chore/common camel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Inflector"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Josh Teeter<joshteeter@gmail.com>"]
 exclude = [".travis.yml", ".gitignore"]
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Documentation can be found here at the README or via rust docs below.
 
 ```toml
 [dependencies]
-Inflector = "0.5.0"
+Inflector = "0.5.1"
 ```
 
 ### Compile yourself:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 0.5.1
+
+## Non-breaking change:
+
+- Refactored Title, Pascal, Train and Camel cases to be unified.
+
 # 0.5.0
 
 ## New features:

--- a/src/cases/camelcase/mod.rs
+++ b/src/cases/camelcase/mod.rs
@@ -1,5 +1,5 @@
 #![deny(warnings)]
-use std::ascii::*;
+use cases::case::*;
 /// Converts a `String` to camelCase `String`
 ///
 /// #Examples
@@ -68,31 +68,14 @@ use std::ascii::*;
 ///
 /// ```
 pub fn to_camel_case(non_camelized_string: String) -> String {
-    let mut new_word: bool = false;
-    let mut last_char: char = ' ';
-    non_camelized_string
-        .chars()
-        .fold("".to_string(), |mut result, character|
-            if character == '-' || character == '_' || character == ' ' {
-                new_word = true;
-                result
-            } else if character.is_numeric() {
-                new_word = true;
-                result.push(character);
-                result
-            } else if new_word || (
-                (last_char.is_lowercase() && character.is_uppercase()) &&
-                (last_char != ' ')
-                ){
-                new_word = false;
-                result.push(character.to_ascii_uppercase());
-                result
-            } else {
-                last_char = character;
-                result.push(character.to_ascii_lowercase());
-                result
-            }
-        )
+    let options = CamelOptions {
+        new_word: false,
+        last_char: ' ',
+        first_word: false,
+        injectable_char: ' ',
+        has_seperator: false
+    };
+    to_case_camel_like(non_camelized_string, options)
 }
 
 /// Determines if a `String` is camelCase bool``

--- a/src/cases/case/mod.rs
+++ b/src/cases/case/mod.rs
@@ -1,6 +1,14 @@
 #![deny(warnings)]
 use std::ascii::*;
 
+pub struct CamelOptions {
+    pub new_word: bool,
+    pub last_char: char,
+    pub first_word: bool,
+    pub injectable_char: char,
+    pub has_seperator: bool
+}
+
 pub fn to_case_snake_like(
     convertable_string: String,
     replace_with: &str,
@@ -12,6 +20,42 @@ pub fn to_case_snake_like(
     } else {
         to_snake_like_from_camel_or_class(convertable_string, replace_with, case)
     }
+}
+
+pub fn to_case_camel_like(
+    convertable_string: String,
+    camel_options: CamelOptions
+    ) -> String {
+    let mut new_word: bool = camel_options.new_word;
+    let mut first_word: bool = camel_options.first_word;
+    let mut last_char: char = camel_options.last_char;
+    convertable_string
+        .chars()
+        .fold("".to_string(), |mut result, character|
+            if character == '-' || character == '_' || character == ' ' {
+                new_word = true;
+                result
+            } else if character.is_numeric() {
+                new_word = true;
+                result.push(character);
+                result
+            } else if new_word || (
+                (last_char.is_lowercase() && character.is_uppercase()) &&
+                (last_char != ' ')
+                ){
+                new_word = false;
+                if !first_word && camel_options.has_seperator {
+                    result.push(camel_options.injectable_char);
+                }
+                first_word = false;
+                result.push(character.to_ascii_uppercase());
+                result
+            } else {
+                last_char = character;
+                result.push(character.to_ascii_lowercase());
+                result
+            }
+        )
 }
 
 fn to_snake_like_from_snake_like(

--- a/src/cases/classcase/mod.rs
+++ b/src/cases/classcase/mod.rs
@@ -1,5 +1,5 @@
 #![deny(warnings)]
-use std::ascii::*;
+use cases::case::*;
 use string::singularize::to_singular;
 /// Converts a `String` to `ClassCase` `String`
 ///
@@ -85,27 +85,14 @@ use string::singularize::to_singular;
 ///
 /// ```
 pub fn to_class_case(non_class_case_string: String) -> String {
-    let mut new_word: bool = true;
-    let mut last_char: char = ' ';
-    let class_plural = non_class_case_string
-        .chars()
-        .fold("".to_string(), |mut result, character|
-            if character == '-' || character == '_' || character == ' ' {
-                new_word = true;
-                result
-            } else if new_word || (
-                (last_char.is_lowercase() && character.is_uppercase()) &&
-                (last_char != ' ')
-                ){
-                new_word = false;
-                result.push(character.to_ascii_uppercase());
-                result
-            } else {
-                last_char = character;
-                result.push(character.to_ascii_lowercase());
-                result
-            }
-        );
+    let options = CamelOptions {
+        new_word: true,
+        last_char: ' ',
+        first_word: false,
+        injectable_char: ' ',
+        has_seperator: false
+    };
+    let class_plural: String = to_case_camel_like(non_class_case_string, options);
     let split: (&str, &str) = class_plural.split_at(class_plural.rfind(char::is_uppercase).unwrap_or(0));
     format!("{}{}", split.0, to_singular(split.1.to_string()))
 }

--- a/src/cases/pascalcase/mod.rs
+++ b/src/cases/pascalcase/mod.rs
@@ -1,5 +1,5 @@
 #![deny(warnings)]
-use std::ascii::*;
+use cases::case::*;
 /// Converts a `String` to pascalCase `String`
 ///
 /// #Examples
@@ -68,31 +68,14 @@ use std::ascii::*;
 ///
 /// ```
 pub fn to_pascal_case(non_pascalized_string: String) -> String {
-    let mut new_word: bool = true;
-    let mut last_char: char = ' ';
-    non_pascalized_string
-        .chars()
-        .fold("".to_string(), |mut result, character|
-            if character == '-' || character == '_' || character == ' ' {
-                new_word = true;
-                result
-            } else if character.is_numeric() {
-                new_word = true;
-                result.push(character);
-                result
-            } else if new_word || (
-                (last_char.is_lowercase() && character.is_uppercase()) &&
-                (last_char != ' ')
-                ){
-                new_word = false;
-                result.push(character.to_ascii_uppercase());
-                result
-            } else {
-                last_char = character;
-                result.push(character.to_ascii_lowercase());
-                result
-            }
-        )
+    let options = CamelOptions {
+        new_word: true,
+        last_char: ' ',
+        first_word: false,
+        injectable_char: ' ',
+        has_seperator: false
+    };
+    to_case_camel_like(non_pascalized_string, options)
 }
 
 /// Determines if a `String` is pascalCase bool``

--- a/src/cases/traincase/mod.rs
+++ b/src/cases/traincase/mod.rs
@@ -1,5 +1,5 @@
 #![deny(warnings)]
-use std::ascii::*;
+use cases::case::*;
 /// Determines if a `String` is `Train-Case`
 ///
 /// #Examples
@@ -129,36 +129,14 @@ pub fn is_train_case(test_string: String) -> bool {
 ///
 /// ```
 pub fn to_train_case(non_train_case_string: String) -> String {
-    let mut new_word: bool = true;
-    let mut first_word: bool = true;
-    let mut last_char: char = ' ';
-    non_train_case_string
-        .chars()
-        .fold("".to_string(), |mut result, character|
-            if character == '-' || character == '_' || character == ' ' {
-                new_word = true;
-                result
-            } else if character.is_numeric() {
-                new_word = true;
-                result.push(character);
-                result
-            } else if new_word || (
-                (last_char.is_lowercase() && character.is_uppercase()) &&
-                (last_char != ' ')
-                ){
-                new_word = false;
-                if !first_word {
-                    result.push('-');
-                }
-                first_word = false;
-                result.push(character.to_ascii_uppercase());
-                result
-            } else {
-                last_char = character;
-                result.push(character.to_ascii_lowercase());
-                result
-            }
-        )
+    let options = CamelOptions {
+        new_word: true,
+        last_char: ' ',
+        first_word: true,
+        injectable_char: '-',
+        has_seperator: true
+    };
+    to_case_camel_like(non_train_case_string, options)
 }
 
 #[cfg(all(feature = "unstable", test))]


### PR DESCRIPTION
# What it does:
- Unifies camel case like conversions under a single method as seen in snake case like

# Why it does it:
- A lot of the code was basically duplicate


# Related issues:
closes #31 
