### PR TITLE
Remove unneccessary lib statements in Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,7 @@ keywords = ["string", "case", "camel", "snake", "inflection"]
 unstable = []
 
 [lib]
-crate_type = ["dylib", "rlib"]
 name = "inflector"
-path = "src/lib.rs"
 
 [dependencies]
 regex = "0.1.73"


### PR DESCRIPTION
# What it does:
The crate-type directives etc. aren't necessary; Cargo is clever enough
to figure out which kind of library to build as per the project's
dependencies.

# Why it does it:
These lines can cause issues when building for other library types.

# Related issues:
N/A