### PR TITLE
Chore/case refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,4 @@ rust:
   - nightly
 after_success:
   - cargo test --features=lightweight --no-default-features
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
-      cargo bench --features=unstable;
-    fi
+  - ./travis-after-success.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 0.8.0
+
+## New features:
+
+- Feature gated pluralize, singularize, class_case, table_case, demodulize, and
+  deconstantize. This can be activated by passing --features=lightweight. See
+  README
+
+
+## Possible breaking change:
+
+- Feature gated items are on by default, meaning that you'll get the full
+  version of the crate if you install as normal. See README if you want to use
+  the lightweight version.
+- Although the application still passes all tests, substantial portions of the
+  core of the conversion code have been method extracted and may have caused a
+  change for some people. Please file an issue if this is a problem for you.
+
 # 0.7.0
 
 ## New features:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ license="BSD-2-Clause"
 description = """
 Adds String based inflections for Rust. Snake, kebab, camel, sentence, class, title and table cases as well as ordinalize, deordinalize, demodulize, foreign key, and pluralize/singularize are supported as both traits and pure functions acting on String types.
 """
-keywords = ["pluralize", "case", "camel", "snake", "inflection"]
+keywords = ["pluralize", "string", "camel", "snake", "inflection"]
+categories = ["text-processing", "value-formatting"]
 
 
 [features]

--- a/benchmark
+++ b/benchmark
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+branch=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
+
+cargo bench --features=unstable>variable &&\
+git stash && \
+git checkout master && \
+cargo bench --features=unstable>control &&\
+cargo benchcmp control variable --threshold 10 &&\
+git checkout $branch &&\
+git stash apply

--- a/src/cases/case/mod.rs
+++ b/src/cases/case/mod.rs
@@ -24,27 +24,17 @@ pub fn to_case_camel_like(convertable_string: String, camel_options: CamelOption
     let mut first_word: bool = camel_options.first_word;
     let mut last_char: char = camel_options.last_char;
     convertable_string.chars()
-        .fold("".to_string(),
-              |mut result, character| if character == '-' || character == '_' || character == ' ' {
+        .fold("".to_string(), |mut result, character|
+              if char_is_seperator(&character) {
                   new_word = true;
                   result
               } else if character.is_numeric() {
                   new_word = true;
                   result.push(character);
                   result
-              } else if new_word ||
-                                                ((last_char.is_lowercase() &&
-                                                  character.is_uppercase()) &&
-                                                 (last_char != ' ')) {
+              } else if last_char_lower_current_is_upper_or_new_word(new_word, &last_char, &character) {
                   new_word = false;
-                  if !first_word && camel_options.has_seperator {
-                      result.push(camel_options.injectable_char);
-                  }
-                  if !camel_options.inverted || first_word {
-                      result.push(character.to_ascii_uppercase());
-                  } else {
-                      result.push(character.to_ascii_lowercase());
-                  }
+                  result = append_on_new_word(result, first_word, character, &camel_options);
                   first_word = false;
                   result
               } else {
@@ -55,37 +45,19 @@ pub fn to_case_camel_like(convertable_string: String, camel_options: CamelOption
 }
 
 #[inline]
-fn to_snake_like_from_snake_like(convertable_string: String,
-                                 replace_with: &str,
-                                 case: &str)
-                                 -> String {
+fn to_snake_like_from_snake_like(convertable_string: String, replace_with: &str, case: &str) -> String {
     let mut new_word: bool = false;
     let mut last_char: char = ' ';
     convertable_string.chars()
-        .fold("".to_string(),
-              |mut result, character| if character == '-' || character == '_' || character == ' ' {
+        .fold("".to_string(), |mut result, character|
+              if char_is_seperator(&character) {
                   new_word = true;
                   result.push(replace_with.chars().nth(0).unwrap_or('_'));
                   result
-              } else if new_word ||
-                                                ((last_char.is_lowercase() &&
-                                                  character.is_uppercase()) &&
-                                                 (last_char != ' ')) {
-                  new_word = false;
-                  if case == "lower" {
-                      result.push(character.to_ascii_lowercase());
-                  } else {
-                      result.push(character.to_ascii_uppercase());
-                  }
-                  result
               } else {
+                  new_word = false;
                   last_char = character;
-                  if case == "lower" {
-                      result.push(character.to_ascii_lowercase());
-                  } else {
-                      result.push(character.to_ascii_uppercase());
-                  }
-                  result
+                  snake_like_no_seperator(result, character, case)
               })
 }
 

--- a/travis-after-success.sh
+++ b/travis-after-success.sh
@@ -14,5 +14,6 @@ if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" != "master" ] && [ "$TRAVIS
     git checkout ${TRAVIS_COMMIT} && \
     cargo bench --features=unstable > benches-variable && \
     cargo install cargo-benchcmp --force && \
-    /home/travis/.cargo/bin/cargo-benchcmp benches-control benches-variable;
+    export PATH=/home/travis/.cargo/bin:$PATH && \
+    cargo benchcmp benches-control benches-variable;
 fi

--- a/travis-after-success.sh
+++ b/travis-after-success.sh
@@ -15,5 +15,5 @@ if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" != "master" ] && [ "$TRAVIS
     cargo bench --features=unstable > benches-variable && \
     cargo install cargo-benchcmp --force && \
     export PATH=/home/travis/.cargo/bin:$PATH && \
-    cargo benchcmp benches-control benches-variable;
+    cargo benchcmp benches-control benches-variable --threshold 7;
 fi

--- a/travis-after-success.sh
+++ b/travis-after-success.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" != "master" ] && [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
+    REMOTE_URL="$(git config --get remote.origin.url)";
+    # Clone the repository fresh..for some reason checking out master fails
+    # from a normal PR build's provided directory
+    cd ${TRAVIS_BUILD_DIR}/.. && \
+    git clone ${REMOTE_URL} "${TRAVIS_REPO_SLUG}-bench" && \
+    cd  "${TRAVIS_REPO_SLUG}-bench" && \
+    # Bench master
+    git checkout master && \
+    cargo bench --features=unstable > benches-control && \
+    # Bench variable
+    git checkout ${TRAVIS_COMMIT} && \
+    cargo bench --features=unstable > benches-variable && \
+    cargo install cargo-benchcmp --force && \
+    /home/travis/.cargo/bin/cargo-benchcmp benches-control benches-variable;
+fi


### PR DESCRIPTION
# What it does:
- Refactors by method extract, the core functionality
- Wraps core functions in tests

# Why it does it:
- The code in case.rs was getting quite complex
- It was also only covered by integration tests

# Benchmarks:

## Master:
```shell
test cases::camelcase::tests::bench_camel0                      ... bench:         141 ns/iter (+/- 39)
test cases::camelcase::tests::bench_camel1                      ... bench:         141 ns/iter (+/- 27)
test cases::camelcase::tests::bench_camel2                      ... bench:         151 ns/iter (+/- 48)
test cases::camelcase::tests::bench_is_camel                    ... bench:         169 ns/iter (+/- 63)
test cases::classcase::tests::bench_class_case                  ... bench:       2,511 ns/iter (+/- 2,079)
test cases::classcase::tests::bench_class_from_snake            ... bench:       2,512 ns/iter (+/- 1,049)
test cases::classcase::tests::bench_is_class                    ... bench:       2,539 ns/iter (+/- 1,003)
test cases::kebabcase::tests::bench_is_kebab                    ... bench:         189 ns/iter (+/- 2)
test cases::kebabcase::tests::bench_kebab                       ... bench:         160 ns/iter (+/- 63)
test cases::kebabcase::tests::bench_kebab_from_snake            ... bench:         257 ns/iter (+/- 126)
test cases::pascalcase::tests::bench_is_pascal                  ... bench:         167 ns/iter (+/- 37)
test cases::pascalcase::tests::bench_pascal0                    ... bench:         145 ns/iter (+/- 75)
test cases::pascalcase::tests::bench_pascal1                    ... bench:         142 ns/iter (+/- 54)
test cases::pascalcase::tests::bench_pascal2                    ... bench:         141 ns/iter (+/- 51)
test cases::screamingsnakecase::tests::bench_is_screaming_snake ... bench:         200 ns/iter (+/- 46)
test cases::screamingsnakecase::tests::bench_screaming_snake    ... bench:         168 ns/iter (+/- 55)
test cases::sentencecase::tests::bench_is_sentence              ... bench:         177 ns/iter (+/- 85)
test cases::sentencecase::tests::bench_sentence                 ... bench:         188 ns/iter (+/- 80)
test cases::sentencecase::tests::bench_sentence_from_snake      ... bench:         146 ns/iter (+/- 74)
test cases::snakecase::tests::bench_is_snake                    ... bench:         189 ns/iter (+/- 69)
test cases::snakecase::tests::bench_snake_from_camel            ... bench:         159 ns/iter (+/- 43)
test cases::snakecase::tests::bench_snake_from_snake            ... bench:         266 ns/iter (+/- 107)
test cases::snakecase::tests::bench_snake_from_title            ... bench:         160 ns/iter (+/- 66)
test cases::tablecase::tests::bench_is_table_case               ... bench:       2,530 ns/iter (+/- 821)
test cases::tablecase::tests::bench_table_case                  ... bench:       2,616 ns/iter (+/- 497)
test cases::titlecase::tests::bench_is_title                    ... bench:         176 ns/iter (+/- 111)
test cases::titlecase::tests::bench_title                       ... bench:         187 ns/iter (+/- 20)
test cases::titlecase::tests::bench_title_from_snake            ... bench:         144 ns/iter (+/- 69)
test cases::traincase::tests::bench_is_train                    ... bench:         175 ns/iter (+/- 74)
test cases::traincase::tests::bench_train                       ... bench:         145 ns/iter (+/- 2)
test cases::traincase::tests::bench_train_from_snake            ... bench:         235 ns/iter (+/- 63)
test tests::benchmark_str_deconstantize                         ... bench:       2,663 ns/iter (+/- 740)
test tests::benchmark_str_demodulize                            ... bench:       2,689 ns/iter (+/- 838)
test tests::benchmark_str_deordinalize                          ... bench:         152 ns/iter (+/- 44)
test tests::benchmark_str_is_camel                              ... bench:         173 ns/iter (+/- 73)
test tests::benchmark_str_is_class                              ... bench:       2,447 ns/iter (+/- 904)
test tests::benchmark_str_is_foreign_key                        ... bench:         235 ns/iter (+/- 82)
test tests::benchmark_str_is_kebab                              ... bench:         191 ns/iter (+/- 114)
test tests::benchmark_str_is_screaming_snake                    ... bench:         204 ns/iter (+/- 29)
test tests::benchmark_str_is_sentence                           ... bench:         177 ns/iter (+/- 63)
test tests::benchmark_str_is_snake                              ... bench:         194 ns/iter (+/- 105)
test tests::benchmark_str_is_table                              ... bench:       2,986 ns/iter (+/- 19)
test tests::benchmark_str_is_title                              ... bench:         177 ns/iter (+/- 2)
test tests::benchmark_str_is_train                              ... bench:         195 ns/iter (+/- 114)
test tests::benchmark_str_ordinalize                            ... bench:         182 ns/iter (+/- 35)
test tests::benchmark_str_pluralize                             ... bench:       2,305 ns/iter (+/- 624)
test tests::benchmark_str_singular                              ... bench:         783 ns/iter (+/- 291)
test tests::benchmark_str_to_camel                              ... bench:         141 ns/iter (+/- 67)
test tests::benchmark_str_to_class                              ... bench:       2,424 ns/iter (+/- 784)
test tests::benchmark_str_to_foreign_key                        ... bench:         465 ns/iter (+/- 89)
test tests::benchmark_str_to_kebab                              ... bench:         159 ns/iter (+/- 31)
test tests::benchmark_str_to_screaming_snake                    ... bench:         169 ns/iter (+/- 75)
test tests::benchmark_str_to_sentence                           ... bench:         142 ns/iter (+/- 24)
test tests::benchmark_str_to_snake                              ... bench:         158 ns/iter (+/- 45)
test tests::benchmark_str_to_table                              ... bench:       2,511 ns/iter (+/- 520)
test tests::benchmark_str_to_title                              ... bench:         143 ns/iter (+/- 40)
test tests::benchmark_str_to_train                              ... bench:         143 ns/iter (+/- 65)
test tests::benchmark_string_deconstantize                      ... bench:       2,687 ns/iter (+/- 860)
test tests::benchmark_string_demodulize                         ... bench:       2,696 ns/iter (+/- 890)
test tests::benchmark_string_deordinalize                       ... bench:         176 ns/iter (+/- 47)
test tests::benchmark_string_is_camel                           ... bench:         196 ns/iter (+/- 65)
test tests::benchmark_string_is_class                           ... bench:       2,473 ns/iter (+/- 155)
test tests::benchmark_string_is_foreign_key                     ... bench:         263 ns/iter (+/- 78)
test tests::benchmark_string_is_kebab                           ... bench:         220 ns/iter (+/- 61)
test tests::benchmark_string_is_screaming_snake                 ... bench:         232 ns/iter (+/- 39)
test tests::benchmark_string_is_sentence                        ... bench:         202 ns/iter (+/- 71)
test tests::benchmark_string_is_snake                           ... bench:         220 ns/iter (+/- 37)
test tests::benchmark_string_is_table                           ... bench:       3,027 ns/iter (+/- 822)
test tests::benchmark_string_is_title                           ... bench:         202 ns/iter (+/- 37)
test tests::benchmark_string_is_train                           ... bench:         201 ns/iter (+/- 55)
test tests::benchmark_string_ordinalize                         ... bench:         206 ns/iter (+/- 79)
test tests::benchmark_string_pluralize                          ... bench:       2,343 ns/iter (+/- 736)
test tests::benchmark_string_singular                           ... bench:         818 ns/iter (+/- 184)
test tests::benchmark_string_to_camel                           ... bench:         166 ns/iter (+/- 81)
test tests::benchmark_string_to_class                           ... bench:       2,448 ns/iter (+/- 751)
test tests::benchmark_string_to_foreign_key                     ... bench:         487 ns/iter (+/- 220)
test tests::benchmark_string_to_kebab                           ... bench:         193 ns/iter (+/- 59)
test tests::benchmark_string_to_screaming_snake                 ... bench:         198 ns/iter (+/- 26)
test tests::benchmark_string_to_sentence                        ... bench:         165 ns/iter (+/- 62)
test tests::benchmark_string_to_snake                           ... bench:         195 ns/iter (+/- 38)
test tests::benchmark_string_to_table                           ... bench:       2,538 ns/iter (+/- 350)
test tests::benchmark_string_to_title                           ... bench:         165 ns/iter (+/- 26)
test tests::benchmark_string_to_train                           ... bench:         165 ns/iter (+/- 31)
```

## This branch
```shell
test cases::camelcase::tests::bench_camel0                      ... bench:         145 ns/iter (+/- 28)
test cases::camelcase::tests::bench_camel1                      ... bench:         151 ns/iter (+/- 84)
test cases::camelcase::tests::bench_camel2                      ... bench:         145 ns/iter (+/- 40)
test cases::camelcase::tests::bench_is_camel                    ... bench:         174 ns/iter (+/- 36)
test cases::classcase::tests::bench_class_case                  ... bench:       2,519 ns/iter (+/- 1,528)
test cases::classcase::tests::bench_class_from_snake            ... bench:       2,635 ns/iter (+/- 1,394)
test cases::classcase::tests::bench_is_class                    ... bench:       2,568 ns/iter (+/- 925)
test cases::kebabcase::tests::bench_is_kebab                    ... bench:         198 ns/iter (+/- 94)
test cases::kebabcase::tests::bench_kebab                       ... bench:         181 ns/iter (+/- 90)
test cases::kebabcase::tests::bench_kebab_from_snake            ... bench:         280 ns/iter (+/- 84)
test cases::pascalcase::tests::bench_is_pascal                  ... bench:         169 ns/iter (+/- 43)
test cases::pascalcase::tests::bench_pascal0                    ... bench:         151 ns/iter (+/- 78)
test cases::pascalcase::tests::bench_pascal1                    ... bench:         153 ns/iter (+/- 87)
test cases::pascalcase::tests::bench_pascal2                    ... bench:         149 ns/iter (+/- 79)
test cases::screamingsnakecase::tests::bench_is_screaming_snake ... bench:         211 ns/iter (+/- 40)
test cases::screamingsnakecase::tests::bench_screaming_snake    ... bench:         179 ns/iter (+/- 70)
test cases::sentencecase::tests::bench_is_sentence              ... bench:         182 ns/iter (+/- 34)
test cases::sentencecase::tests::bench_sentence                 ... bench:         203 ns/iter (+/- 114)
test cases::sentencecase::tests::bench_sentence_from_snake      ... bench:         162 ns/iter (+/- 89)
test cases::snakecase::tests::bench_is_snake                    ... bench:         198 ns/iter (+/- 87)
test cases::snakecase::tests::bench_snake_from_camel            ... bench:         181 ns/iter (+/- 45)
test cases::snakecase::tests::bench_snake_from_snake            ... bench:         284 ns/iter (+/- 77)
test cases::snakecase::tests::bench_snake_from_title            ... bench:         172 ns/iter (+/- 104)
test cases::tablecase::tests::bench_is_table_case               ... bench:       2,500 ns/iter (+/- 544)
test cases::tablecase::tests::bench_table_case                  ... bench:       2,480 ns/iter (+/- 977)
test cases::titlecase::tests::bench_is_title                    ... bench:         182 ns/iter (+/- 7)
test cases::titlecase::tests::bench_title                       ... bench:         207 ns/iter (+/- 121)
test cases::titlecase::tests::bench_title_from_snake            ... bench:         159 ns/iter (+/- 12)
test cases::traincase::tests::bench_is_train                    ... bench:         199 ns/iter (+/- 118)
test cases::traincase::tests::bench_train                       ... bench:         159 ns/iter (+/- 84)
test cases::traincase::tests::bench_train_from_snake            ... bench:         254 ns/iter (+/- 40)
test tests::benchmark_str_deconstantize                         ... bench:       2,681 ns/iter (+/- 1,004)
test tests::benchmark_str_demodulize                            ... bench:       2,978 ns/iter (+/- 2,031)
test tests::benchmark_str_deordinalize                          ... bench:         147 ns/iter (+/- 47)
test tests::benchmark_str_is_camel                              ... bench:         174 ns/iter (+/- 87)
test tests::benchmark_str_is_class                              ... bench:       2,459 ns/iter (+/- 683)
test tests::benchmark_str_is_foreign_key                        ... bench:         238 ns/iter (+/- 95)
test tests::benchmark_str_is_kebab                              ... bench:         214 ns/iter (+/- 67)
test tests::benchmark_str_is_screaming_snake                    ... bench:         217 ns/iter (+/- 35)
test tests::benchmark_str_is_sentence                           ... bench:         182 ns/iter (+/- 4)
test tests::benchmark_str_is_snake                              ... bench:         204 ns/iter (+/- 41)
test tests::benchmark_str_is_table                              ... bench:       2,978 ns/iter (+/- 763)
test tests::benchmark_str_is_title                              ... bench:         182 ns/iter (+/- 34)
test tests::benchmark_str_is_train                              ... bench:         204 ns/iter (+/- 107)
test tests::benchmark_str_ordinalize                            ... bench:         198 ns/iter (+/- 65)
test tests::benchmark_str_pluralize                             ... bench:       2,304 ns/iter (+/- 529)
test tests::benchmark_str_singular                              ... bench:         811 ns/iter (+/- 302)
test tests::benchmark_str_to_camel                              ... bench:         145 ns/iter (+/- 49)
test tests::benchmark_str_to_class                              ... bench:       2,415 ns/iter (+/- 421)
test tests::benchmark_str_to_foreign_key                        ... bench:         475 ns/iter (+/- 126)
test tests::benchmark_str_to_kebab                              ... bench:         181 ns/iter (+/- 47)
test tests::benchmark_str_to_screaming_snake                    ... bench:         212 ns/iter (+/- 97)
test tests::benchmark_str_to_sentence                           ... bench:         166 ns/iter (+/- 87)
test tests::benchmark_str_to_snake                              ... bench:         181 ns/iter (+/- 57)
test tests::benchmark_str_to_table                              ... bench:       2,505 ns/iter (+/- 572)
test tests::benchmark_str_to_title                              ... bench:         155 ns/iter (+/- 69)
test tests::benchmark_str_to_train                              ... bench:         155 ns/iter (+/- 64)
test tests::benchmark_string_deconstantize                      ... bench:       2,707 ns/iter (+/- 30)
test tests::benchmark_string_demodulize                         ... bench:       2,724 ns/iter (+/- 644)
test tests::benchmark_string_deordinalize                       ... bench:         171 ns/iter (+/- 44)
test tests::benchmark_string_is_camel                           ... bench:         204 ns/iter (+/- 71)
test tests::benchmark_string_is_class                           ... bench:       2,472 ns/iter (+/- 637)
test tests::benchmark_string_is_foreign_key                     ... bench:         267 ns/iter (+/- 30)
test tests::benchmark_string_is_kebab                           ... bench:         239 ns/iter (+/- 127)
test tests::benchmark_string_is_screaming_snake                 ... bench:         241 ns/iter (+/- 47)
test tests::benchmark_string_is_sentence                        ... bench:         208 ns/iter (+/- 95)
test tests::benchmark_string_is_snake                           ... bench:         228 ns/iter (+/- 142)
test tests::benchmark_string_is_table                           ... bench:       2,986 ns/iter (+/- 711)
test tests::benchmark_string_is_title                           ... bench:         210 ns/iter (+/- 63)
test tests::benchmark_string_is_train                           ... bench:         219 ns/iter (+/- 124)
test tests::benchmark_string_ordinalize                         ... bench:         215 ns/iter (+/- 3)
test tests::benchmark_string_pluralize                          ... bench:       2,297 ns/iter (+/- 520)
test tests::benchmark_string_singular                           ... bench:         844 ns/iter (+/- 370)
test tests::benchmark_string_to_camel                           ... bench:         169 ns/iter (+/- 42)
test tests::benchmark_string_to_class                           ... bench:       2,436 ns/iter (+/- 519)
test tests::benchmark_string_to_foreign_key                     ... bench:         500 ns/iter (+/- 104)
test tests::benchmark_string_to_kebab                           ... bench:         210 ns/iter (+/- 42)
test tests::benchmark_string_to_screaming_snake                 ... bench:         227 ns/iter (+/- 87)
test tests::benchmark_string_to_sentence                        ... bench:         175 ns/iter (+/- 68)
test tests::benchmark_string_to_snake                           ... bench:         211 ns/iter (+/- 99)
test tests::benchmark_string_to_table                           ... bench:       2,540 ns/iter (+/- 770)
test tests::benchmark_string_to_title                           ... bench:         172 ns/iter (+/- 3)
test tests::benchmark_string_to_train                           ... bench:         190 ns/iter (+/- 117)
```