### PR TITLE
Feature flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rust:
   - beta
   - nightly
 after_success:
+  - cargo test --features=without_full --no-default-features
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
       cargo bench --features=unstable;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
   - beta
   - nightly
 after_success:
-  - cargo test --features=without_full --no-default-features
+  - cargo test --features=lightweight --no-default-features
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
       cargo bench --features=unstable;
     fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["pluralize", "case", "camel", "snake", "inflection"]
 [features]
 default = ['regex', 'lazy_static']
 unstable = []
-without_full = []
+lightweight = []
 
 [lib]
 name = "inflector"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Inflector"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Josh Teeter<joshteeter@gmail.com>"]
 exclude = [".travis.yml", ".gitignore"]
 readme = "README.md"
@@ -13,12 +13,15 @@ Adds String based inflections for Rust. Snake, kebab, camel, sentence, class, ti
 """
 keywords = ["pluralize", "case", "camel", "snake", "inflection"]
 
+
 [features]
+default = ['regex', 'lazy_static']
 unstable = []
+without_full = []
 
 [lib]
 name = "inflector"
 
 [dependencies]
-regex = "0.2"
-lazy_static = "0.2.2"
+regex = {version = "0.2", optional = true}
+lazy_static = {version = "0.2.2", optional = true}

--- a/README.md
+++ b/README.md
@@ -106,6 +106,23 @@ fn main() {
 
 ```
 
+## Advanced installation and usage:
+
+If the project doesn't require singularize, pluralize, class, table, demodulize,
+deconstantize. Then in your `cargo.toml` you should specify:
+
+```toml
+[dependencies.Inflector]
+version = "*"
+features = ["without_full"]
+```
+
+To test this crate locally with features off try:
+
+```shell
+cargo test --features=without_full --no-default-features
+```
+
 ## [Contributing](CONTRIBUTING.md)
 
 This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/README.md
+++ b/README.md
@@ -114,13 +114,13 @@ deconstantize. Then in your `cargo.toml` you should specify:
 ```toml
 [dependencies.Inflector]
 version = "*"
-features = ["without_full"]
+features = ["lightweight"]
 ```
 
 To test this crate locally with features off try:
 
 ```shell
-cargo test --features=without_full --no-default-features
+cargo test --features=lightweight --no-default-features
 ```
 
 ## [Contributing](CONTRIBUTING.md)

--- a/src/cases/case/mod.rs
+++ b/src/cases/case/mod.rs
@@ -164,7 +164,7 @@ macro_rules! define_gated_tests{
     ($method: ident; $($test_name:ident => $to_convert:expr => $expected:expr ), *) => {
         $(
             #[test]
-            #[cfg(not(feature = "without_full"))]
+            #[cfg(not(feature = "lightweight"))]
             fn $test_name() {
                 assert_eq!($method($to_convert.to_string()), $expected.to_string())
             }

--- a/src/cases/case/mod.rs
+++ b/src/cases/case/mod.rs
@@ -143,20 +143,34 @@ macro_rules! define_test_group {
             define_tests![
                 $method;
                 from_camel_case             => "fooBar"     => $expected,
-                from_class_case             => "FooBar"     => $expected,
                 from_screaming_snake_case   => "FOO_BAR"    => $expected,
                 from_kebab_case             => "foo-bar"    => $expected,
                 from_pascal_case            => "FooBar"     => $expected,
                 from_sentence_case          => "Foo bar"    => $expected,
                 from_snake_case             => "foo_bar"    => $expected,
                 from_title_case             => "Foo Bar"    => $expected,
-                from_table_case             => "foo_bars"   => $expected_plural,
                 from_train_case             => "Foo-Bars"   => $expected_plural
+            ];
+            define_gated_tests![
+                $method;
+                from_class_case             => "FooBar"     => $expected,
+                from_table_case             => "foo_bars"   => $expected_plural
             ];
         }
     }
 }
 
+macro_rules! define_gated_tests{
+    ($method: ident; $($test_name:ident => $to_convert:expr => $expected:expr ), *) => {
+        $(
+            #[test]
+            #[cfg(not(feature = "without_full"))]
+            fn $test_name() {
+                assert_eq!($method($to_convert.to_string()), $expected.to_string())
+            }
+        )*
+    }
+}
 macro_rules! define_tests{
     ($method: ident; $($test_name:ident => $to_convert:expr => $expected:expr ), *) => {
         $(

--- a/src/cases/classcase/mod.rs
+++ b/src/cases/classcase/mod.rs
@@ -1,6 +1,9 @@
 #![deny(warnings)]
+#[cfg(not(feature = "without_full"))]
 use cases::case::*;
+#[cfg(not(feature = "without_full"))]
 use string::singularize::to_singular;
+#[cfg(not(feature = "without_full"))]
 /// Converts a `String` to `ClassCase` `String`
 ///
 /// ```
@@ -98,6 +101,7 @@ pub fn to_class_case(non_class_case_string: String) -> String {
     format!("{}{}", split.0, to_singular(split.1.to_string()))
 }
 
+#[cfg(not(feature = "without_full"))]
 /// Determines if a `String` is `ClassCase` `bool`
 ///
 /// ```
@@ -194,6 +198,7 @@ pub fn is_class_case(test_string: String) -> bool {
 }
 
 #[cfg(all(feature = "unstable", test))]
+#[cfg(not(feature = "without_full"))]
 mod tests {
     extern crate test;
     use self::test::Bencher;
@@ -214,4 +219,5 @@ mod tests {
     }
 }
 
+#[cfg(not(feature = "without_full"))]
 define_test_group!(class_tests, to_class_case, classcase, "FooBar", "FooBar");

--- a/src/cases/classcase/mod.rs
+++ b/src/cases/classcase/mod.rs
@@ -1,9 +1,9 @@
 #![deny(warnings)]
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 use cases::case::*;
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 use string::singularize::to_singular;
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 /// Converts a `String` to `ClassCase` `String`
 ///
 /// ```
@@ -101,7 +101,7 @@ pub fn to_class_case(non_class_case_string: String) -> String {
     format!("{}{}", split.0, to_singular(split.1.to_string()))
 }
 
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 /// Determines if a `String` is `ClassCase` `bool`
 ///
 /// ```
@@ -198,7 +198,7 @@ pub fn is_class_case(test_string: String) -> bool {
 }
 
 #[cfg(all(feature = "unstable", test))]
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 mod tests {
     extern crate test;
     use self::test::Bencher;
@@ -219,5 +219,5 @@ mod tests {
     }
 }
 
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 define_test_group!(class_tests, to_class_case, classcase, "FooBar", "FooBar");

--- a/src/cases/tablecase/mod.rs
+++ b/src/cases/tablecase/mod.rs
@@ -1,9 +1,9 @@
 #![deny(warnings)]
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 use string::pluralize::to_plural;
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 use cases::case::*;
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 /// Converts a `String` to `table-case` `String`
 ///
 /// ```
@@ -67,7 +67,7 @@ pub fn to_table_case(non_table_case_string: String) -> String {
     format!("{}{}", split.0, to_plural(split.1.to_string()))
 }
 
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 /// Determines if a `String` is `table-case`
 ///
 /// ```
@@ -130,7 +130,7 @@ pub fn is_table_case(test_string: String) -> bool {
 }
 
 #[cfg(all(feature = "unstable", test))]
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 mod tests {
     extern crate test;
     use self::test::Bencher;
@@ -146,7 +146,7 @@ mod tests {
     }
 }
 
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 define_test_group!(table_tests,
                    to_table_case,
                    tablecase,

--- a/src/cases/tablecase/mod.rs
+++ b/src/cases/tablecase/mod.rs
@@ -1,6 +1,9 @@
 #![deny(warnings)]
+#[cfg(not(feature = "without_full"))]
 use string::pluralize::to_plural;
+#[cfg(not(feature = "without_full"))]
 use cases::case::*;
+#[cfg(not(feature = "without_full"))]
 /// Converts a `String` to `table-case` `String`
 ///
 /// ```
@@ -63,6 +66,8 @@ pub fn to_table_case(non_table_case_string: String) -> String {
     let split: (&str, &str) = snaked.split_at(snaked.rfind('_').unwrap_or(0));
     format!("{}{}", split.0, to_plural(split.1.to_string()))
 }
+
+#[cfg(not(feature = "without_full"))]
 /// Determines if a `String` is `table-case`
 ///
 /// ```
@@ -125,6 +130,7 @@ pub fn is_table_case(test_string: String) -> bool {
 }
 
 #[cfg(all(feature = "unstable", test))]
+#[cfg(not(feature = "without_full"))]
 mod tests {
     extern crate test;
     use self::test::Bencher;
@@ -140,6 +146,7 @@ mod tests {
     }
 }
 
+#[cfg(not(feature = "without_full"))]
 define_test_group!(table_tests,
                    to_table_case,
                    tablecase,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,10 @@
 //! let is_camel_cased: bool= camel_case_string.is_camel_case();
 //! assert!(is_camel_cased == true);
 //! ```
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 extern crate regex;
 
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 #[macro_use] extern crate lazy_static;
 /// Provides case inflections
 /// - Camel case
@@ -39,13 +39,13 @@ pub mod suffix;
 /// - Demodulize
 /// - Pluralize
 /// - Singularize
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 pub mod string;
 
 
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 use cases::classcase::to_class_case;
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 use cases::classcase::is_class_case;
 
 use cases::camelcase::to_camel_case;
@@ -72,9 +72,9 @@ use cases::sentencecase::is_sentence_case;
 use cases::titlecase::to_title_case;
 use cases::titlecase::is_title_case;
 
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 use cases::tablecase::to_table_case;
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 use cases::tablecase::is_table_case;
 
 use numbers::ordinalize::ordinalize;
@@ -83,14 +83,14 @@ use numbers::deordinalize::deordinalize;
 use suffix::foreignkey::to_foreign_key;
 use suffix::foreignkey::is_foreign_key;
 
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 use string::demodulize::demodulize;
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 use string::deconstantize::deconstantize;
 
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 use string::pluralize::to_plural;
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 use string::singularize::to_singular;
 
 #[allow(missing_docs)]
@@ -126,22 +126,22 @@ pub trait Inflector {
     fn to_foreign_key(&self) -> String;
     fn is_foreign_key(&self) -> bool;
 
-    #[cfg(not(feature = "without_full"))]
+    #[cfg(not(feature = "lightweight"))]
     fn demodulize(&self) -> String;
-    #[cfg(not(feature = "without_full"))]
+    #[cfg(not(feature = "lightweight"))]
     fn deconstantize(&self) -> String;
 
-    #[cfg(not(feature = "without_full"))]
+    #[cfg(not(feature = "lightweight"))]
     fn to_class_case(&self) -> String;
-    #[cfg(not(feature = "without_full"))]
+    #[cfg(not(feature = "lightweight"))]
     fn is_class_case(&self) -> bool;
-    #[cfg(not(feature = "without_full"))]
+    #[cfg(not(feature = "lightweight"))]
     fn to_table_case(&self) -> String;
-    #[cfg(not(feature = "without_full"))]
+    #[cfg(not(feature = "lightweight"))]
     fn is_table_case(&self) -> bool;
-    #[cfg(not(feature = "without_full"))]
+    #[cfg(not(feature = "lightweight"))]
     fn to_plural(&self) -> String;
-    #[cfg(not(feature = "without_full"))]
+    #[cfg(not(feature = "lightweight"))]
     fn to_singular(&self) -> String;
 }
 
@@ -167,7 +167,7 @@ macro_rules! define_gated_implementations {
     ( $slf:ident; $($imp_trait:ident => $typ:ident), *) => {
         $(
             #[inline]
-            #[cfg(not(feature = "without_full"))]
+            #[cfg(not(feature = "lightweight"))]
             fn $imp_trait(&$slf) -> $typ {
                 $imp_trait($slf.to_string())
             }
@@ -296,7 +296,7 @@ mod tests {
         benchmark_string_is_foreign_key => is_foreign_key => "bar_id".to_string()
     ];
 
-    #[cfg(not(feature = "without_full"))]
+    #[cfg(not(feature = "lightweight"))]
     benchmarks![
         benchmark_str_to_class => to_class_case => "foo",
         benchmark_str_is_class => is_class_case => "Foo",

--- a/src/string/deconstantize/mod.rs
+++ b/src/string/deconstantize/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 use cases::classcase::to_class_case;
 
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 /// Deconstantizes a `String`
 ///
 /// ```

--- a/src/string/deconstantize/mod.rs
+++ b/src/string/deconstantize/mod.rs
@@ -1,5 +1,7 @@
+#[cfg(not(feature = "without_full"))]
 use cases::classcase::to_class_case;
 
+#[cfg(not(feature = "without_full"))]
 /// Deconstantizes a `String`
 ///
 /// ```

--- a/src/string/demodulize/mod.rs
+++ b/src/string/demodulize/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 use cases::classcase::to_class_case;
 
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 /// Demodulize a `String`
 ///
 /// ```

--- a/src/string/demodulize/mod.rs
+++ b/src/string/demodulize/mod.rs
@@ -1,5 +1,7 @@
+#[cfg(not(feature = "without_full"))]
 use cases::classcase::to_class_case;
 
+#[cfg(not(feature = "without_full"))]
 /// Demodulize a `String`
 ///
 /// ```

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -2,22 +2,22 @@
 /// Provides demodulize a string.
 ///
 /// Example string `Foo::Bar` becomes `Bar`
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 pub mod demodulize;
 /// Provides deconstantizea string.
 ///
 /// Example string `Foo::Bar` becomes `Foo`
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 pub mod deconstantize;
 /// Provides conversion to plural strings.
 ///
 /// Example string `FooBar` -> `FooBars`
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 pub mod pluralize;
 /// Provides conversion to singular strings.
 ///
 /// Example string `FooBars` -> `FooBar`
-#[cfg(not(feature = "without_full"))]
+#[cfg(not(feature = "lightweight"))]
 pub mod singularize;
 
 mod constants;

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -2,18 +2,22 @@
 /// Provides demodulize a string.
 ///
 /// Example string `Foo::Bar` becomes `Bar`
+#[cfg(not(feature = "without_full"))]
 pub mod demodulize;
 /// Provides deconstantizea string.
 ///
 /// Example string `Foo::Bar` becomes `Foo`
+#[cfg(not(feature = "without_full"))]
 pub mod deconstantize;
 /// Provides conversion to plural strings.
 ///
 /// Example string `FooBar` -> `FooBars`
+#[cfg(not(feature = "without_full"))]
 pub mod pluralize;
 /// Provides conversion to singular strings.
 ///
 /// Example string `FooBars` -> `FooBar`
+#[cfg(not(feature = "without_full"))]
 pub mod singularize;
 
 mod constants;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -38,13 +38,47 @@ macro_rules! number_tests {
     }
 }
 
+macro_rules! gated_str_tests {
+    ( $($test_name:ident => $imp_trait:ident => $to_cast:expr => $casted:expr), *) => {
+        $(
+            #[test]
+            #[cfg(not(feature = "without_full"))]
+            fn $test_name() {
+                assert_eq!($to_cast.$imp_trait(), $casted)
+            }
+        )*
+    }
+}
+
+macro_rules! gated_string_tests {
+    ( $($test_name:ident => $imp_trait:ident => $to_cast:expr => $casted:expr), *) => {
+        $(
+            #[test]
+            #[cfg(not(feature = "without_full"))]
+            fn $test_name() {
+                assert_eq!($to_cast.to_string().$imp_trait(), $casted)
+            }
+        )*
+    }
+}
+
+macro_rules! gated_number_tests {
+    ( $($test_name:ident => $imp_trait:ident => $typ:ident => $to_cast:expr => $casted:expr), *) => {
+        $(
+            #[test]
+            #[cfg(not(feature = "without_full"))]
+            fn $test_name() {
+                let to_cast: $typ = $to_cast;
+                assert_eq!(to_cast.$imp_trait(), $casted)
+            }
+        )*
+    }
+}
+
+
 str_tests![
-    str_to_class => to_class_case => "foo" => "Foo".to_string(),
-    str_is_class => is_class_case => "Foo" => true,
     str_to_camel => to_camel_case => "foo_bar" => "fooBar".to_string(),
     str_is_camel => is_camel_case => "fooBar" => true,
-    str_to_table => to_table_case => "fooBar" => "foo_bars".to_string(),
-    str_is_table => is_table_case => "foo_bars" => true,
     str_to_screaming_snake => to_screaming_snake_case => "fooBar" => "FOO_BAR".to_string(),
     str_is_screaming_snake => is_screaming_snake_case => "FOO_BAR" => true,
     str_to_snake => to_snake_case => "fooBar" => "foo_bar".to_string(),
@@ -60,20 +94,23 @@ str_tests![
     str_ordinalize  => ordinalize => "1" => "1st".to_string(),
     str_deordinalize  => deordinalize => "1st" => "1".to_string(),
     str_to_foreign_key => to_foreign_key => "Foo::Bar" => "bar_id".to_string(),
-    str_is_foreign_key => is_foreign_key => "bar_id" => true,
-    str_demodulize => demodulize => "Foo::Bar" => "Bar".to_string(),
-    str_deconstantize => deconstantize => "Foo::Bar" => "Foo".to_string(),
+    str_is_foreign_key => is_foreign_key => "bar_id" => true
+];
+
+gated_str_tests![
+    str_to_class => to_class_case => "foo" => "Foo".to_string(),
+    str_is_class => is_class_case => "Foo" => true,
+    str_to_table => to_table_case => "fooBar" => "foo_bars".to_string(),
+    str_is_table => is_table_case => "foo_bars" => true,
     str_pluralize => to_plural => "crate" => "crates".to_string(),
-    str_singular => to_singular => "crates" => "crate".to_string()
+    str_singular => to_singular => "crates" => "crate".to_string(),
+    str_demodulize => demodulize => "Foo::Bar" => "Bar".to_string(),
+    str_deconstantize => deconstantize => "Foo::Bar" => "Foo".to_string()
 ];
 
 string_tests![
-    string_to_class => to_class_case => "foo" => "Foo".to_string(),
-    string_is_class => is_class_case => "Foo" => true,
     string_to_camel => to_camel_case => "foo_bar" => "fooBar".to_string(),
     string_is_camel => is_camel_case => "fooBar" => true,
-    string_to_table => to_table_case => "fooBar" => "foo_bars".to_string(),
-    string_is_table => is_table_case => "foo_bars" => true,
     string_to_screaming_snake => to_screaming_snake_case => "fooBar" => "FOO_BAR".to_string(),
     string_is_screaming_snake => is_screaming_snake_case => "FOO_BAR" => true,
     string_to_snake => to_snake_case => "fooBar" => "foo_bar".to_string(),
@@ -89,11 +126,18 @@ string_tests![
     string_ordinalize  => ordinalize => "1" => "1st".to_string(),
     string_deordinalize  => deordinalize => "1st" => "1".to_string(),
     string_to_foreign_key => to_foreign_key => "Foo::Bar" => "bar_id".to_string(),
-    string_is_foreign_key => is_foreign_key => "bar_id" => true,
-    string_demodulize => demodulize => "Foo::Bar" => "Bar".to_string(),
-    string_deconstantize => deconstantize => "Foo::Bar" => "Foo".to_string(),
+    string_is_foreign_key => is_foreign_key => "bar_id" => true
+];
+
+gated_string_tests![
+    string_to_class => to_class_case => "foo" => "Foo".to_string(),
+    string_is_class => is_class_case => "Foo" => true,
+    string_to_table => to_table_case => "fooBar" => "foo_bars".to_string(),
+    string_is_table => is_table_case => "foo_bars" => true,
     string_pluralize => to_plural => "crate" => "crates".to_string(),
-    string_singular => to_singular => "crates" => "crate".to_string()
+    string_singular => to_singular => "crates" => "crate".to_string(),
+    string_demodulize => demodulize => "Foo::Bar" => "Bar".to_string(),
+    string_deconstantize => deconstantize => "Foo::Bar" => "Foo".to_string()
 ];
 
 number_tests![

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -42,7 +42,7 @@ macro_rules! gated_str_tests {
     ( $($test_name:ident => $imp_trait:ident => $to_cast:expr => $casted:expr), *) => {
         $(
             #[test]
-            #[cfg(not(feature = "without_full"))]
+            #[cfg(not(feature = "lightweight"))]
             fn $test_name() {
                 assert_eq!($to_cast.$imp_trait(), $casted)
             }
@@ -54,7 +54,7 @@ macro_rules! gated_string_tests {
     ( $($test_name:ident => $imp_trait:ident => $to_cast:expr => $casted:expr), *) => {
         $(
             #[test]
-            #[cfg(not(feature = "without_full"))]
+            #[cfg(not(feature = "lightweight"))]
             fn $test_name() {
                 assert_eq!($to_cast.to_string().$imp_trait(), $casted)
             }
@@ -66,7 +66,7 @@ macro_rules! gated_number_tests {
     ( $($test_name:ident => $imp_trait:ident => $typ:ident => $to_cast:expr => $casted:expr), *) => {
         $(
             #[test]
-            #[cfg(not(feature = "without_full"))]
+            #[cfg(not(feature = "lightweight"))]
             fn $test_name() {
                 let to_cast: $typ = $to_cast;
                 assert_eq!(to_cast.$imp_trait(), $casted)


### PR DESCRIPTION
# What it does:
- Adds feature flags on heavier methods in the library
- The features are enabled by default

# Why it does it:
- Pluralize, singularize, etc can be heavy and require in two dependencies. This resolves that by making more items optional

# Related issues:
https://github.com/serde-rs/serde/pull/788
