### PR TITLE
Fix singularization of ies suffix

### DIFF
--- a/src/string/singularize/mod.rs
+++ b/src/string/singularize/mod.rs
@@ -122,6 +122,7 @@ lazy_static!{
     static ref RULES: Vec<(Regex, &'static str)> = {
     let mut r = Vec::new();
     rules![r;
+     r"(\w*)s$" => "",
      r"(n)ews$" => "ews",
      r"(\w*)(o)es$" => "",
      r"(\w*)([ti])a$" => "um",
@@ -131,7 +132,7 @@ lazy_static!{
      r"(\w*)(hive)s$" => "",
      r"(\w*)(tive)s$" => "",
      r"(\w*)([lr])ves$" => "f",
-     r"(\w*)([^aeiouy]|qu)ies$" => "y",
+     r"(\w*([^aeiouy]|qu))ies$" => "y",
      r"(s)eries$" => "eries",
      r"(m)ovies$" => "ovie",
      r"(\w*)(x|ch|ss|sh)es$" => "",
@@ -147,11 +148,17 @@ lazy_static!{
      r"(matr)ices$" => "ix",
      r"(quiz)zes$" => "",
      r"(database)s$" => "",
-     r"(\w*)s$" => "",
      r"(\w*)(ss)$" => ""
          ];
      r
     };
+}
+
+#[test]
+fn singularize_ies_suffix() {
+    assert_eq!("reply", to_singular("replies".to_owned()));
+    assert_eq!("lady", to_singular("ladies".to_owned()));
+    assert_eq!("soliloquy", to_singular("soliloquies".to_owned()));
 }
 
 #[test]


### PR DESCRIPTION
# What it does:
Fixes issues with singularizing "-ies" suffix words (e.g. "replies", "queries", etc.).

# Why it does it:
In current master, "-ies" suffix words are singularized by chopping off the trailing "s", giving results of "replie", "querie", etc. This is due to the ordering of the singularization rules having the most basic "remove trailing s" rule being one of the first ones checked. Also fixes a bug in the regex that was causing the matched character before the "-ies" suffix to be removed.

# Related issues:
None