### PR TITLE
Feature/&str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.9.0
+
+## Breaking changes:
+- Changed type signature for all casting methods to use `&str`. This gives the
+  crate a >10% increase in performance in a majority of conversions. Although
+  most users only use:
+     `"my_string".to_camel_case()`
+  or
+    `"myString".to_string().to_snake_case()`
+  For those using the `to_camel_case("something".to_string())` this will be a
+  breaking change as the new syntax demands `to_camel_case("something")`.
+
+
 # 0.8.1
 
 ## Bugfixes:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Inflector"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Josh Teeter<joshteeter@gmail.com>"]
 exclude = [".travis.yml", ".gitignore"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ Adds String based inflections for Rust. Snake, kebab, camel, sentence, class, ti
 keywords = ["pluralize", "string", "camel", "snake", "inflection"]
 categories = ["text-processing", "value-formatting"]
 
+[badges]
+travis-ci = { repository = "whatisinternet/inflector" }
 
 [features]
 default = ['heavyweight']

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Rust Inflector
 
 
-[![Build Status](https://travis-ci.org/whatisinternet/inflector.svg?branch=master)](https://travis-ci.org/whatisinternet/inflector) [![Crates.io](https://img.shields.io/crates/v/inflector.svg)](https://crates.io/crates/inflector)
+[![Build Status](https://travis-ci.org/whatisinternet/inflector.svg?branch=master)](https://travis-ci.org/whatisinternet/inflector) [![Crates.io](https://img.shields.io/crates/v/inflector.svg)](https://crates.io/crates/inflector) [![codecov](https://codecov.io/gh/whatisinternet/inflector/branch/master/graph/badge.svg)](https://codecov.io/gh/whatisinternet/inflector)
+
 
 Adds String based inflections for Rust. Snake, kebab, train, camel,
 sentence, class, and title cases as well as ordinalize,

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Adds String based inflections for Rust. Snake, kebab, train, camel,
 sentence, class, and title cases as well as ordinalize,
 deordinalize, demodulize, deconstantize, foreign key, table case, and pluralize/singularize are supported as both traits and pure functions
-acting on String types.
+acting on &str and String types.
 
 -----
 ## Documentation:
@@ -53,7 +53,7 @@ Or
 
 ```rust
 ...
-// to use methods like to_snake_case(String);
+// to use methods like to_snake_case(&str);
 extern crate inflector;
 
 // use inflector::cases::classcase::to_class_case;
@@ -100,7 +100,7 @@ extern crate inflector;
 ...
 fn main() {
 ...
-  let camel_case_string: String = to_camel_case("some_string".to_string());
+  let camel_case_string: String = to_camel_case("some_string");
 ...
 }
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rust Inflector
 
 
-[![Build Status](https://travis-ci.org/whatisinternet/inflector.svg?branch=master)](https://travis-ci.org/whatisinternet/inflector) [![Crates.io](https://img.shields.io/crates/v/inflector.svg)](https://crates.io/crates/inflector) [![codecov](https://codecov.io/gh/whatisinternet/inflector/branch/master/graph/badge.svg)](https://codecov.io/gh/whatisinternet/inflector)
+[![Build Status](https://travis-ci.org/whatisinternet/inflector.svg?branch=master)](https://travis-ci.org/whatisinternet/inflector) [![codecov](https://codecov.io/gh/whatisinternet/inflector/branch/master/graph/badge.svg)](https://codecov.io/gh/whatisinternet/inflector) [![Crates.io](https://img.shields.io/crates/v/inflector.svg)](https://crates.io/crates/inflector)
 
 
 Adds String based inflections for Rust. Snake, kebab, train, camel,

--- a/src/cases/camelcase/mod.rs
+++ b/src/cases/camelcase/mod.rs
@@ -1,11 +1,11 @@
 #![deny(warnings)]
 use cases::case::*;
 
-/// Converts a `String` to camelCase `String`
+/// Converts a `&str` to camelCase `String`
 ///
 /// ```
 ///     use inflector::cases::camelcase::to_camel_case;
-///     let mock_string: String = "fooBar".to_string();
+///     let mock_string: &str = "fooBar";
 ///     let expected_string: String = "fooBar".to_string();
 ///     let asserted_string: String = to_camel_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -13,7 +13,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::to_camel_case;
-///     let mock_string: String = "FOO_BAR".to_string();
+///     let mock_string: &str = "FOO_BAR";
 ///     let expected_string: String = "fooBar".to_string();
 ///     let asserted_string: String = to_camel_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -21,7 +21,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::to_camel_case;
-///     let mock_string: String = "Foo Bar".to_string();
+///     let mock_string: &str = "Foo Bar";
 ///     let expected_string: String = "fooBar".to_string();
 ///     let asserted_string: String = to_camel_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -29,7 +29,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::to_camel_case;
-///     let mock_string: String = "foo_bar".to_string();
+///     let mock_string: &str = "foo_bar";
 ///     let expected_string: String = "fooBar".to_string();
 ///     let asserted_string: String = to_camel_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -37,7 +37,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::to_camel_case;
-///     let mock_string: String = "Foo bar".to_string();
+///     let mock_string: &str = "Foo bar";
 ///     let expected_string: String = "fooBar".to_string();
 ///     let asserted_string: String = to_camel_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -45,7 +45,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::to_camel_case;
-///     let mock_string: String = "foo-bar".to_string();
+///     let mock_string: &str = "foo-bar";
 ///     let expected_string: String = "fooBar".to_string();
 ///     let asserted_string: String = to_camel_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -53,7 +53,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::to_camel_case;
-///     let mock_string: String = "FooBar".to_string();
+///     let mock_string: &str = "FooBar";
 ///     let expected_string: String = "fooBar".to_string();
 ///     let asserted_string: String = to_camel_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -61,7 +61,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::to_camel_case;
-///     let mock_string: String = "FooBar3".to_string();
+///     let mock_string: &str = "FooBar3";
 ///     let expected_string: String = "fooBar3".to_string();
 ///     let asserted_string: String = to_camel_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -69,13 +69,13 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::to_camel_case;
-///     let mock_string: String = "Foo-Bar".to_string();
+///     let mock_string: &str = "Foo-Bar";
 ///     let expected_string: String = "fooBar".to_string();
 ///     let asserted_string: String = to_camel_case(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_camel_case(non_camelized_string: String) -> String {
+pub fn to_camel_case(non_camelized_string: &str) -> String {
     let options = CamelOptions {
         new_word: false,
         last_char: ' ',
@@ -84,14 +84,14 @@ pub fn to_camel_case(non_camelized_string: String) -> String {
         has_seperator: false,
         inverted: false,
     };
-    to_case_camel_like(non_camelized_string, options)
+    to_case_camel_like(&non_camelized_string, options)
 }
 
-/// Determines if a `String` is camelCase bool``
+/// Determines if a `&str` is camelCase bool``
 ///
 /// ```
 ///     use inflector::cases::camelcase::is_camel_case;
-///     let mock_string: String = "Foo".to_string();
+///     let mock_string: &str = "Foo";
 ///     let asserted_bool: bool = is_camel_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -99,7 +99,7 @@ pub fn to_camel_case(non_camelized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::is_camel_case;
-///     let mock_string: String = "foo".to_string();
+///     let mock_string: &str = "foo";
 ///     let asserted_bool: bool = is_camel_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
@@ -107,7 +107,7 @@ pub fn to_camel_case(non_camelized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::is_camel_case;
-///     let mock_string: String = "foo-bar-string-that-is-really-really-long".to_string();
+///     let mock_string: &str = "foo-bar-string-that-is-really-really-long";
 ///     let asserted_bool: bool = is_camel_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -115,7 +115,7 @@ pub fn to_camel_case(non_camelized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::is_camel_case;
-///     let mock_string: String = "FooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "FooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_camel_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -123,7 +123,7 @@ pub fn to_camel_case(non_camelized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::is_camel_case;
-///     let mock_string: String = "fooBarIsAReallyReally3LongString".to_string();
+///     let mock_string: &str = "fooBarIsAReallyReally3LongString";
 ///     let asserted_bool: bool = is_camel_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
@@ -131,7 +131,7 @@ pub fn to_camel_case(non_camelized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::is_camel_case;
-///     let mock_string: String = "fooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "fooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_camel_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
@@ -139,7 +139,7 @@ pub fn to_camel_case(non_camelized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::is_camel_case;
-///     let mock_string: String = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG".to_string();
+///     let mock_string: &str = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG";
 ///     let asserted_bool: bool = is_camel_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -147,7 +147,7 @@ pub fn to_camel_case(non_camelized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::is_camel_case;
-///     let mock_string: String = "foo_bar_string_that_is_really_really_long".to_string();
+///     let mock_string: &str = "foo_bar_string_that_is_really_really_long";
 ///     let asserted_bool: bool = is_camel_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -155,7 +155,7 @@ pub fn to_camel_case(non_camelized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::is_camel_case;
-///     let mock_string: String = "Foo bar string that is really really long".to_string();
+///     let mock_string: &str = "Foo bar string that is really really long";
 ///     let asserted_bool: bool = is_camel_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -163,12 +163,12 @@ pub fn to_camel_case(non_camelized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::camelcase::is_camel_case;
-///     let mock_string: String = "Foo Bar Is A Really Really Long String".to_string();
+///     let mock_string: &str = "Foo Bar Is A Really Really Long String";
 ///     let asserted_bool: bool = is_camel_case(mock_string);
 ///     assert!(asserted_bool == false);
 /// ```
-pub fn is_camel_case(test_string: String) -> bool {
-    to_camel_case(test_string.clone()) == test_string
+pub fn is_camel_case(test_string: &str) -> bool {
+    to_camel_case(&test_string.clone()) == test_string
 }
 
 #[cfg(all(feature = "unstable", test))]
@@ -179,7 +179,7 @@ mod tests {
     #[bench]
     fn bench_camel0(b: &mut Bencher) {
         b.iter(|| {
-            let test_string = "Foo bar".to_string();
+            let test_string = "Foo bar";
             super::to_camel_case(test_string)
         });
     }
@@ -187,7 +187,7 @@ mod tests {
     #[bench]
     fn bench_camel1(b: &mut Bencher) {
         b.iter(|| {
-            let test_string = "foo_bar".to_string();
+            let test_string = "foo_bar";
             super::to_camel_case(test_string)
         });
     }
@@ -195,7 +195,7 @@ mod tests {
     #[bench]
     fn bench_camel2(b: &mut Bencher) {
         b.iter(|| {
-            let test_string = "fooBar".to_string();
+            let test_string = "fooBar";
             super::to_camel_case(test_string)
         });
     }
@@ -203,7 +203,7 @@ mod tests {
     #[bench]
     fn bench_is_camel(b: &mut Bencher) {
         b.iter(|| {
-            let test_string: String = "Foo bar".to_string();
+            let test_string: &str = "Foo bar";
             super::is_camel_case(test_string)
         });
     }

--- a/src/cases/case/mod.rs
+++ b/src/cases/case/mod.rs
@@ -10,16 +10,16 @@ pub struct CamelOptions {
     pub inverted: bool,
 }
 
-pub fn to_case_snake_like(convertable_string: String, replace_with: &str, case: &str) -> String {
+pub fn to_case_snake_like(convertable_string: &str, replace_with: &str, case: &str) -> String {
     let seperators: &[char] = &[' ', '-', '_'];
     if convertable_string.contains(seperators) {
-        to_snake_like_from_snake_like(convertable_string, replace_with, case)
+        to_snake_like_from_snake_like(&convertable_string, replace_with, case)
     } else {
-        to_snake_like_from_camel_or_class(convertable_string, replace_with, case)
+        to_snake_like_from_camel_or_class(&convertable_string, replace_with, case)
     }
 }
 
-pub fn to_case_camel_like(convertable_string: String, camel_options: CamelOptions) -> String {
+pub fn to_case_camel_like(convertable_string: &str, camel_options: CamelOptions) -> String {
     let mut new_word: bool = camel_options.new_word;
     let mut first_word: bool = camel_options.first_word;
     let mut last_char: char = camel_options.last_char;
@@ -45,7 +45,7 @@ pub fn to_case_camel_like(convertable_string: String, camel_options: CamelOption
 }
 
 #[inline]
-fn to_snake_like_from_snake_like(convertable_string: String, replace_with: &str, case: &str) -> String {
+fn to_snake_like_from_snake_like(convertable_string: &str, replace_with: &str, case: &str) -> String {
     let mut new_word: bool = false;
     let mut last_char: char = ' ';
     convertable_string.chars()
@@ -62,7 +62,7 @@ fn to_snake_like_from_snake_like(convertable_string: String, replace_with: &str,
 }
 
 #[inline]
-fn to_snake_like_from_camel_or_class(convertable_string: String,
+fn to_snake_like_from_camel_or_class(convertable_string: &str,
                                      replace_with: &str,
                                      case: &str)
                                      -> String {
@@ -186,7 +186,7 @@ macro_rules! define_gated_tests{
             #[test]
             #[cfg(feature = "heavyweight")]
             fn $test_name() {
-                assert_eq!($method($to_convert.to_string()), $expected.to_string())
+                assert_eq!($method($to_convert), $expected.to_string())
             }
         )*
     }
@@ -196,7 +196,7 @@ macro_rules! define_tests{
         $(
             #[test]
             fn $test_name() {
-                assert_eq!($method($to_convert.to_string()), $expected.to_string())
+                assert_eq!($method($to_convert), $expected.to_string())
             }
         )*
     }
@@ -224,22 +224,22 @@ fn test_next_or_previous_char_is_lowercase_false() {
 
 #[test]
 fn snake_like_with_seperator_lowers() {
-    assert_eq!(snake_like_with_seperator("".to_string(), "^", &'c', "lower"), "^c".to_string())
+    assert_eq!(snake_like_with_seperator("".to_owned(), "^", &'c', "lower"), "^c".to_string())
 }
 
 #[test]
 fn snake_like_with_seperator_upper() {
-    assert_eq!(snake_like_with_seperator("".to_string(), "^", &'c', "upper"), "^C".to_string())
+    assert_eq!(snake_like_with_seperator("".to_owned(), "^", &'c', "upper"), "^C".to_string())
 }
 
 #[test]
 fn snake_like_no_seperator_lower() {
-    assert_eq!(snake_like_no_seperator("".to_string(), 'C', "lower"), "c".to_string())
+    assert_eq!(snake_like_no_seperator("".to_owned(), 'C', "lower"), "c".to_string())
 }
 
 #[test]
 fn snake_like_no_seperator_upper() {
-    assert_eq!(snake_like_no_seperator("".to_string(), 'c', "upper"), "C".to_string())
+    assert_eq!(snake_like_no_seperator("".to_owned(), 'c', "upper"), "C".to_string())
 }
 
 #[test]

--- a/src/cases/case/mod.rs
+++ b/src/cases/case/mod.rs
@@ -57,7 +57,7 @@ fn to_snake_like_from_snake_like(convertable_string: &str, replace_with: &str, c
               } else {
                   new_word = false;
                   last_char = character;
-                  snake_like_no_seperator(result, character, case)
+                  snake_like_no_seperator(result, &character, case)
               })
 }
 
@@ -74,7 +74,7 @@ fn to_snake_like_from_camel_or_class(convertable_string: &str,
                   snake_like_with_seperator(acc, replace_with, &char_with_index.1, case)
               } else {
                   first_character = false;
-                  snake_like_no_seperator(acc, char_with_index.1, case)
+                  snake_like_no_seperator(acc, &char_with_index.1, case)
               })
 }
 
@@ -118,7 +118,7 @@ fn requires_seperator(char_with_index: (usize, char), first_character: bool, con
 }
 
 #[inline]
-fn snake_like_no_seperator(mut accumlator: String, current_char: char, case: &str) -> String {
+fn snake_like_no_seperator(mut accumlator: String, current_char: &char, case: &str) -> String {
     if case == "lower" {
         accumlator.push(current_char.to_ascii_lowercase());
         accumlator
@@ -234,12 +234,12 @@ fn snake_like_with_seperator_upper() {
 
 #[test]
 fn snake_like_no_seperator_lower() {
-    assert_eq!(snake_like_no_seperator("".to_owned(), 'C', "lower"), "c".to_string())
+    assert_eq!(snake_like_no_seperator("".to_owned(), &'C', "lower"), "c".to_string())
 }
 
 #[test]
 fn snake_like_no_seperator_upper() {
-    assert_eq!(snake_like_no_seperator("".to_owned(), 'c', "upper"), "C".to_string())
+    assert_eq!(snake_like_no_seperator("".to_owned(), &'c', "upper"), "C".to_string())
 }
 
 #[test]

--- a/src/cases/classcase/mod.rs
+++ b/src/cases/classcase/mod.rs
@@ -4,11 +4,11 @@ use cases::case::*;
 #[cfg(feature = "heavyweight")]
 use string::singularize::to_singular;
 #[cfg(feature = "heavyweight")]
-/// Converts a `String` to `ClassCase` `String`
+/// Converts a `&str` to `ClassCase` `String`
 ///
 /// ```
 ///     use inflector::cases::classcase::to_class_case;
-///     let mock_string: String = "FooBar".to_string();
+///     let mock_string: &str = "FooBar";
 ///     let expected_string: String = "FooBar".to_string();
 ///     let asserted_string: String = to_class_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -17,7 +17,7 @@ use string::singularize::to_singular;
 ///
 /// ```
 ///     use inflector::cases::classcase::to_class_case;
-///     let mock_string: String = "FooBars".to_string();
+///     let mock_string: &str = "FooBars";
 ///     let expected_string: String = "FooBar".to_string();
 ///     let asserted_string: String = to_class_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -26,7 +26,7 @@ use string::singularize::to_singular;
 ///
 /// ```
 ///     use inflector::cases::classcase::to_class_case;
-///     let mock_string: String = "Foo Bar".to_string();
+///     let mock_string: &str = "Foo Bar";
 ///     let expected_string: String = "FooBar".to_string();
 ///     let asserted_string: String = to_class_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -35,7 +35,7 @@ use string::singularize::to_singular;
 ///
 /// ```
 ///     use inflector::cases::classcase::to_class_case;
-///     let mock_string: String = "foo-bar".to_string();
+///     let mock_string: &str = "foo-bar";
 ///     let expected_string: String = "FooBar".to_string();
 ///     let asserted_string: String = to_class_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -44,7 +44,7 @@ use string::singularize::to_singular;
 ///
 /// ```
 ///     use inflector::cases::classcase::to_class_case;
-///     let mock_string: String = "fooBar".to_string();
+///     let mock_string: &str = "fooBar";
 ///     let expected_string: String = "FooBar".to_string();
 ///     let asserted_string: String = to_class_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -53,7 +53,7 @@ use string::singularize::to_singular;
 ///
 /// ```
 ///     use inflector::cases::classcase::to_class_case;
-///     let mock_string: String = "FOO_BAR".to_string();
+///     let mock_string: &str = "FOO_BAR";
 ///     let expected_string: String = "FooBar".to_string();
 ///     let asserted_string: String = to_class_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -62,7 +62,7 @@ use string::singularize::to_singular;
 ///
 /// ```
 ///     use inflector::cases::classcase::to_class_case;
-///     let mock_string: String = "foo_bar".to_string();
+///     let mock_string: &str = "foo_bar";
 ///     let expected_string: String = "FooBar".to_string();
 ///     let asserted_string: String = to_class_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -71,7 +71,7 @@ use string::singularize::to_singular;
 ///
 /// ```
 ///     use inflector::cases::classcase::to_class_case;
-///     let mock_string: String = "foo_bars".to_string();
+///     let mock_string: &str = "foo_bars";
 ///     let expected_string: String = "FooBar".to_string();
 ///     let asserted_string: String = to_class_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -80,13 +80,13 @@ use string::singularize::to_singular;
 ///
 /// ```
 ///     use inflector::cases::classcase::to_class_case;
-///     let mock_string: String = "Foo bar".to_string();
+///     let mock_string: &str = "Foo bar";
 ///     let expected_string: String = "FooBar".to_string();
 ///     let asserted_string: String = to_class_case(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_class_case(non_class_case_string: String) -> String {
+pub fn to_class_case(non_class_case_string: &str) -> String {
     let options = CamelOptions {
         new_word: true,
         last_char: ' ',
@@ -98,15 +98,15 @@ pub fn to_class_case(non_class_case_string: String) -> String {
     let class_plural: String = to_case_camel_like(non_class_case_string, options);
     let split: (&str, &str) =
         class_plural.split_at(class_plural.rfind(char::is_uppercase).unwrap_or(0));
-    format!("{}{}", split.0, to_singular(split.1.to_string()))
+    format!("{}{}", split.0, to_singular(split.1))
 }
 
 #[cfg(feature = "heavyweight")]
-/// Determines if a `String` is `ClassCase` `bool`
+/// Determines if a `&str` is `ClassCase` `bool`
 ///
 /// ```
 ///     use inflector::cases::classcase::is_class_case;
-///     let mock_string: String = "Foo".to_string();
+///     let mock_string: &str = "Foo";
 ///     let asserted_bool: bool = is_class_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
@@ -114,7 +114,7 @@ pub fn to_class_case(non_class_case_string: String) -> String {
 ///
 /// ```
 ///     use inflector::cases::classcase::is_class_case;
-///     let mock_string: String = "foo".to_string();
+///     let mock_string: &str = "foo";
 ///     let asserted_bool: bool = is_class_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -122,7 +122,7 @@ pub fn to_class_case(non_class_case_string: String) -> String {
 ///
 /// ```
 ///     use inflector::cases::classcase::is_class_case;
-///     let mock_string: String = "FooBarIsAReallyReallyLongStrings".to_string();
+///     let mock_string: &str = "FooBarIsAReallyReallyLongStrings";
 ///     let asserted_bool: bool = is_class_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -131,7 +131,7 @@ pub fn to_class_case(non_class_case_string: String) -> String {
 ///
 /// ```
 ///     use inflector::cases::classcase::is_class_case;
-///     let mock_string: String = "FooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "FooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_class_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
@@ -139,7 +139,7 @@ pub fn to_class_case(non_class_case_string: String) -> String {
 ///
 /// ```
 ///     use inflector::cases::classcase::is_class_case;
-///     let mock_string: String = "foo-bar-string-that-is-really-really-long".to_string();
+///     let mock_string: &str = "foo-bar-string-that-is-really-really-long";
 ///     let asserted_bool: bool = is_class_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -147,7 +147,7 @@ pub fn to_class_case(non_class_case_string: String) -> String {
 ///
 /// ```
 ///     use inflector::cases::classcase::is_class_case;
-///     let mock_string: String = "foo_bar_is_a_really_really_long_strings".to_string();
+///     let mock_string: &str = "foo_bar_is_a_really_really_long_strings";
 ///     let asserted_bool: bool = is_class_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -156,7 +156,7 @@ pub fn to_class_case(non_class_case_string: String) -> String {
 ///
 /// ```
 ///     use inflector::cases::classcase::is_class_case;
-///     let mock_string: String = "fooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "fooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_class_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -164,7 +164,7 @@ pub fn to_class_case(non_class_case_string: String) -> String {
 ///
 /// ```
 ///     use inflector::cases::classcase::is_class_case;
-///     let mock_string: String = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG".to_string();
+///     let mock_string: &str = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG";
 ///     let asserted_bool: bool = is_class_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -172,7 +172,7 @@ pub fn to_class_case(non_class_case_string: String) -> String {
 ///
 /// ```
 ///     use inflector::cases::classcase::is_class_case;
-///     let mock_string: String = "foo_bar_string_that_is_really_really_long".to_string();
+///     let mock_string: &str = "foo_bar_string_that_is_really_really_long";
 ///     let asserted_bool: bool = is_class_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -180,7 +180,7 @@ pub fn to_class_case(non_class_case_string: String) -> String {
 ///
 /// ```
 ///     use inflector::cases::classcase::is_class_case;
-///     let mock_string: String = "Foo bar string that is really really long".to_string();
+///     let mock_string: &str = "Foo bar string that is really really long";
 ///     let asserted_bool: bool = is_class_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -188,12 +188,12 @@ pub fn to_class_case(non_class_case_string: String) -> String {
 ///
 /// ```
 ///     use inflector::cases::classcase::is_class_case;
-///     let mock_string: String = "Foo Bar Is A Really Really Long String".to_string();
+///     let mock_string: &str = "Foo Bar Is A Really Really Long String";
 ///     let asserted_bool: bool = is_class_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
-pub fn is_class_case(test_string: String) -> bool {
+pub fn is_class_case(test_string: &str) -> bool {
     test_string == to_class_case(test_string.clone())
 }
 
@@ -205,17 +205,17 @@ mod tests {
 
     #[bench]
     fn bench_class_case(b: &mut Bencher) {
-        b.iter(|| super::to_class_case("Foo bar".to_string()));
+        b.iter(|| super::to_class_case("Foo bar"));
     }
 
     #[bench]
     fn bench_is_class(b: &mut Bencher) {
-        b.iter(|| super::is_class_case("Foo bar".to_string()));
+        b.iter(|| super::is_class_case("Foo bar"));
     }
 
     #[bench]
     fn bench_class_from_snake(b: &mut Bencher) {
-        b.iter(|| super::to_class_case("foo_bar".to_string()));
+        b.iter(|| super::to_class_case("foo_bar"));
     }
 }
 

--- a/src/cases/kebabcase/mod.rs
+++ b/src/cases/kebabcase/mod.rs
@@ -1,10 +1,10 @@
 #![deny(warnings)]
 use cases::case::*;
-/// Determines if a `String` is `kebab-case`
+/// Determines if a `&str` is `kebab-case`
 ///
 /// ```
 ///     use inflector::cases::kebabcase::is_kebab_case;
-///     let mock_string: String = "foo-bar-string-that-is-really-really-long".to_string();
+///     let mock_string: &str = "foo-bar-string-that-is-really-really-long";
 ///     let asserted_bool: bool = is_kebab_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
@@ -12,7 +12,7 @@ use cases::case::*;
 ///
 /// ```
 ///     use inflector::cases::kebabcase::is_kebab_case;
-///     let mock_string: String = "FooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "FooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_kebab_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -20,7 +20,7 @@ use cases::case::*;
 ///
 /// ```
 ///     use inflector::cases::kebabcase::is_kebab_case;
-///     let mock_string: String = "fooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "fooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_kebab_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -28,7 +28,7 @@ use cases::case::*;
 ///
 /// ```
 ///     use inflector::cases::kebabcase::is_kebab_case;
-///     let mock_string: String = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG".to_string();
+///     let mock_string: &str = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG";
 ///     let asserted_bool: bool = is_kebab_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -36,7 +36,7 @@ use cases::case::*;
 ///
 /// ```
 ///     use inflector::cases::kebabcase::is_kebab_case;
-///     let mock_string: String = "foo_bar_string_that_is_really_really_long".to_string();
+///     let mock_string: &str = "foo_bar_string_that_is_really_really_long";
 ///     let asserted_bool: bool = is_kebab_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -44,7 +44,7 @@ use cases::case::*;
 ///
 /// ```
 ///     use inflector::cases::kebabcase::is_kebab_case;
-///     let mock_string: String = "Foo bar string that is really really long".to_string();
+///     let mock_string: &str = "Foo bar string that is really really long";
 ///     let asserted_bool: bool = is_kebab_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -52,20 +52,20 @@ use cases::case::*;
 ///
 /// ```
 ///     use inflector::cases::kebabcase::is_kebab_case;
-///     let mock_string: String = "Foo Bar Is A Really Really Long String".to_string();
+///     let mock_string: &str = "Foo Bar Is A Really Really Long String";
 ///     let asserted_bool: bool = is_kebab_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
-pub fn is_kebab_case(test_string: String) -> bool {
+pub fn is_kebab_case(test_string: &str) -> bool {
     test_string == to_kebab_case(test_string.clone())
 }
 
-/// Converts a `String` to `kebab-case` `String`
+/// Converts a `&str` to `kebab-case` `String`
 ///
 /// ```
 ///     use inflector::cases::kebabcase::to_kebab_case;
-///     let mock_string: String = "foo-bar".to_string();
+///     let mock_string: &str = "foo-bar";
 ///     let expected_string: String = "foo-bar".to_string();
 ///     let asserted_string: String = to_kebab_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -74,7 +74,7 @@ pub fn is_kebab_case(test_string: String) -> bool {
 ///
 /// ```
 ///     use inflector::cases::kebabcase::to_kebab_case;
-///     let mock_string: String = "FOO_BAR".to_string();
+///     let mock_string: &str = "FOO_BAR";
 ///     let expected_string: String = "foo-bar".to_string();
 ///     let asserted_string: String = to_kebab_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -83,7 +83,7 @@ pub fn is_kebab_case(test_string: String) -> bool {
 ///
 /// ```
 ///     use inflector::cases::kebabcase::to_kebab_case;
-///     let mock_string: String = "foo_bar".to_string();
+///     let mock_string: &str = "foo_bar";
 ///     let expected_string: String = "foo-bar".to_string();
 ///     let asserted_string: String = to_kebab_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -92,7 +92,7 @@ pub fn is_kebab_case(test_string: String) -> bool {
 ///
 /// ```
 ///     use inflector::cases::kebabcase::to_kebab_case;
-///     let mock_string: String = "Foo Bar".to_string();
+///     let mock_string: &str = "Foo Bar";
 ///     let expected_string: String = "foo-bar".to_string();
 ///     let asserted_string: String = to_kebab_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -101,7 +101,7 @@ pub fn is_kebab_case(test_string: String) -> bool {
 ///
 /// ```
 ///     use inflector::cases::kebabcase::to_kebab_case;
-///     let mock_string: String = "Foo bar".to_string();
+///     let mock_string: &str = "Foo bar";
 ///     let expected_string: String = "foo-bar".to_string();
 ///     let asserted_string: String = to_kebab_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -110,7 +110,7 @@ pub fn is_kebab_case(test_string: String) -> bool {
 ///
 /// ```
 ///     use inflector::cases::kebabcase::to_kebab_case;
-///     let mock_string: String = "FooBar".to_string();
+///     let mock_string: &str = "FooBar";
 ///     let expected_string: String = "foo-bar".to_string();
 ///     let asserted_string: String = to_kebab_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -119,13 +119,13 @@ pub fn is_kebab_case(test_string: String) -> bool {
 ///
 /// ```
 ///     use inflector::cases::kebabcase::to_kebab_case;
-///     let mock_string: String = "fooBar".to_string();
+///     let mock_string: &str = "fooBar";
 ///     let expected_string: String = "foo-bar".to_string();
 ///     let asserted_string: String = to_kebab_case(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_kebab_case(non_kebab_case_string: String) -> String {
+pub fn to_kebab_case(non_kebab_case_string: &str) -> String {
     to_case_snake_like(non_kebab_case_string, "-", "lower")
 }
 
@@ -136,17 +136,17 @@ mod tests {
 
     #[bench]
     fn bench_kebab(b: &mut Bencher) {
-        b.iter(|| super::to_kebab_case("Foo bar".to_string()));
+        b.iter(|| super::to_kebab_case("Foo bar"));
     }
 
     #[bench]
     fn bench_is_kebab(b: &mut Bencher) {
-        b.iter(|| super::is_kebab_case("Foo bar".to_string()));
+        b.iter(|| super::is_kebab_case("Foo bar"));
     }
 
     #[bench]
     fn bench_kebab_from_snake(b: &mut Bencher) {
-        b.iter(|| super::to_kebab_case("test_test_test".to_string()));
+        b.iter(|| super::to_kebab_case("test_test_test"));
     }
 }
 

--- a/src/cases/pascalcase/mod.rs
+++ b/src/cases/pascalcase/mod.rs
@@ -1,10 +1,10 @@
 #![deny(warnings)]
 use cases::case::*;
-/// Converts a `String` to pascalCase `String`
+/// Converts a `&str` to pascalCase `String`
 ///
 /// ```
 ///     use inflector::cases::pascalcase::to_pascal_case;
-///     let mock_string: String = "fooBar".to_string();
+///     let mock_string: &str = "fooBar";
 ///     let expected_string: String = "FooBar".to_string();
 ///     let asserted_string: String = to_pascal_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -12,7 +12,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::pascalcase::to_pascal_case;
-///     let mock_string: String = "FOO_BAR".to_string();
+///     let mock_string: &str = "FOO_BAR";
 ///     let expected_string: String = "FooBar".to_string();
 ///     let asserted_string: String = to_pascal_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -20,7 +20,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::pascalcase::to_pascal_case;
-///     let mock_string: String = "Foo Bar".to_string();
+///     let mock_string: &str = "Foo Bar";
 ///     let expected_string: String = "FooBar".to_string();
 ///     let asserted_string: String = to_pascal_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -28,7 +28,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::pascalcase::to_pascal_case;
-///     let mock_string: String = "foo_bar".to_string();
+///     let mock_string: &str = "foo_bar";
 ///     let expected_string: String = "FooBar".to_string();
 ///     let asserted_string: String = to_pascal_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -36,7 +36,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::pascalcase::to_pascal_case;
-///     let mock_string: String = "Foo bar".to_string();
+///     let mock_string: &str = "Foo bar";
 ///     let expected_string: String = "FooBar".to_string();
 ///     let asserted_string: String = to_pascal_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -44,7 +44,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::pascalcase::to_pascal_case;
-///     let mock_string: String = "foo-bar".to_string();
+///     let mock_string: &str = "foo-bar";
 ///     let expected_string: String = "FooBar".to_string();
 ///     let asserted_string: String = to_pascal_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -52,7 +52,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::pascalcase::to_pascal_case;
-///     let mock_string: String = "FooBar".to_string();
+///     let mock_string: &str = "FooBar";
 ///     let expected_string: String = "FooBar".to_string();
 ///     let asserted_string: String = to_pascal_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -60,13 +60,13 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::pascalcase::to_pascal_case;
-///     let mock_string: String = "FooBar3".to_string();
+///     let mock_string: &str = "FooBar3";
 ///     let expected_string: String = "FooBar3".to_string();
 ///     let asserted_string: String = to_pascal_case(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_pascal_case(non_pascalized_string: String) -> String {
+pub fn to_pascal_case(non_pascalized_string: &str) -> String {
     let options = CamelOptions {
         new_word: true,
         last_char: ' ',
@@ -78,11 +78,11 @@ pub fn to_pascal_case(non_pascalized_string: String) -> String {
     to_case_camel_like(non_pascalized_string, options)
 }
 
-/// Determines if a `String` is pascalCase bool``
+/// Determines if a `&str` is pascalCase bool``
 ///
 /// ```
 ///     use inflector::cases::pascalcase::is_pascal_case;
-///     let mock_string: String = "Foo".to_string();
+///     let mock_string: &str = "Foo";
 ///     let asserted_bool: bool = is_pascal_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
@@ -90,7 +90,7 @@ pub fn to_pascal_case(non_pascalized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::pascalcase::is_pascal_case;
-///     let mock_string: String = "foo".to_string();
+///     let mock_string: &str = "foo";
 ///     let asserted_bool: bool = is_pascal_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -98,7 +98,7 @@ pub fn to_pascal_case(non_pascalized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::pascalcase::is_pascal_case;
-///     let mock_string: String = "foo-bar-string-that-is-really-really-long".to_string();
+///     let mock_string: &str = "foo-bar-string-that-is-really-really-long";
 ///     let asserted_bool: bool = is_pascal_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -106,7 +106,7 @@ pub fn to_pascal_case(non_pascalized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::pascalcase::is_pascal_case;
-///     let mock_string: String = "FooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "FooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_pascal_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
@@ -114,7 +114,7 @@ pub fn to_pascal_case(non_pascalized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::pascalcase::is_pascal_case;
-///     let mock_string: String = "FooBarIsAReallyReally3LongString".to_string();
+///     let mock_string: &str = "FooBarIsAReallyReally3LongString";
 ///     let asserted_bool: bool = is_pascal_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
@@ -122,7 +122,7 @@ pub fn to_pascal_case(non_pascalized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::pascalcase::is_pascal_case;
-///     let mock_string: String = "FooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "FooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_pascal_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
@@ -130,7 +130,7 @@ pub fn to_pascal_case(non_pascalized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::pascalcase::is_pascal_case;
-///     let mock_string: String = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG".to_string();
+///     let mock_string: &str = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG";
 ///     let asserted_bool: bool = is_pascal_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -138,7 +138,7 @@ pub fn to_pascal_case(non_pascalized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::pascalcase::is_pascal_case;
-///     let mock_string: String = "foo_bar_string_that_is_really_really_long".to_string();
+///     let mock_string: &str = "foo_bar_string_that_is_really_really_long";
 ///     let asserted_bool: bool = is_pascal_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -146,7 +146,7 @@ pub fn to_pascal_case(non_pascalized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::pascalcase::is_pascal_case;
-///     let mock_string: String = "Foo bar string that is really really long".to_string();
+///     let mock_string: &str = "Foo bar string that is really really long";
 ///     let asserted_bool: bool = is_pascal_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -154,11 +154,11 @@ pub fn to_pascal_case(non_pascalized_string: String) -> String {
 /// ```
 /// ```
 ///     use inflector::cases::pascalcase::is_pascal_case;
-///     let mock_string: String = "Foo Bar Is A Really Really Long String".to_string();
+///     let mock_string: &str = "Foo Bar Is A Really Really Long String";
 ///     let asserted_bool: bool = is_pascal_case(mock_string);
 ///     assert!(asserted_bool == false);
 /// ```
-pub fn is_pascal_case(test_string: String) -> bool {
+pub fn is_pascal_case(test_string: &str) -> bool {
     to_pascal_case(test_string.clone()) == test_string
 }
 
@@ -170,7 +170,7 @@ mod tests {
     #[bench]
     fn bench_pascal0(b: &mut Bencher) {
         b.iter(|| {
-            let test_string = "Foo bar".to_string();
+            let test_string = "Foo bar";
             super::to_pascal_case(test_string)
         });
     }
@@ -178,7 +178,7 @@ mod tests {
     #[bench]
     fn bench_pascal1(b: &mut Bencher) {
         b.iter(|| {
-            let test_string = "foo_bar".to_string();
+            let test_string = "foo_bar";
             super::to_pascal_case(test_string)
         });
     }
@@ -186,7 +186,7 @@ mod tests {
     #[bench]
     fn bench_pascal2(b: &mut Bencher) {
         b.iter(|| {
-            let test_string = "fooBar".to_string();
+            let test_string = "fooBar";
             super::to_pascal_case(test_string)
         });
     }
@@ -194,7 +194,7 @@ mod tests {
     #[bench]
     fn bench_is_pascal(b: &mut Bencher) {
         b.iter(|| {
-            let test_string: String = "Foo bar".to_string();
+            let test_string: &str = "Foo bar";
             super::is_pascal_case(test_string)
         });
     }

--- a/src/cases/screamingsnakecase/mod.rs
+++ b/src/cases/screamingsnakecase/mod.rs
@@ -1,10 +1,10 @@
 #![deny(warnings)]
 use cases::case::*;
-/// Converts a `String` to `SCREAMING_SNAKE_CASE` `String`
+/// Converts a `&str` to `SCREAMING_SNAKE_CASE` `String`
 ///
 /// ```
 ///     use inflector::cases::screamingsnakecase::to_screaming_snake_case;
-///     let mock_string: String = "foo_bar".to_string();
+///     let mock_string: &str = "foo_bar";
 ///     let expected_string: String = "FOO_BAR".to_string();
 ///     let asserted_string: String = to_screaming_snake_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -12,7 +12,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::screamingsnakecase::to_screaming_snake_case;
-///     let mock_string: String = "HTTP Foo bar".to_string();
+///     let mock_string: &str = "HTTP Foo bar";
 ///     let expected_string: String = "HTTP_FOO_BAR".to_string();
 ///     let asserted_string: String = to_screaming_snake_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -20,7 +20,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::screamingsnakecase::to_screaming_snake_case;
-///     let mock_string: String = "Foo bar".to_string();
+///     let mock_string: &str = "Foo bar";
 ///     let expected_string: String = "FOO_BAR".to_string();
 ///     let asserted_string: String = to_screaming_snake_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -28,7 +28,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::screamingsnakecase::to_screaming_snake_case;
-///     let mock_string: String = "Foo Bar".to_string();
+///     let mock_string: &str = "Foo Bar";
 ///     let expected_string: String = "FOO_BAR".to_string();
 ///     let asserted_string: String = to_screaming_snake_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -36,7 +36,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::screamingsnakecase::to_screaming_snake_case;
-///     let mock_string: String = "FooBar".to_string();
+///     let mock_string: &str = "FooBar";
 ///     let expected_string: String = "FOO_BAR".to_string();
 ///     let asserted_string: String = to_screaming_snake_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -44,7 +44,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::screamingsnakecase::to_screaming_snake_case;
-///     let mock_string: String = "fooBar".to_string();
+///     let mock_string: &str = "fooBar";
 ///     let expected_string: String = "FOO_BAR".to_string();
 ///     let asserted_string: String = to_screaming_snake_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -52,75 +52,75 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::screamingsnakecase::to_screaming_snake_case;
-///     let mock_string: String = "fooBar3".to_string();
+///     let mock_string: &str = "fooBar3";
 ///     let expected_string: String = "FOO_BAR_3".to_string();
 ///     let asserted_string: String = to_screaming_snake_case(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_screaming_snake_case(non_snake_case_string: String) -> String {
+pub fn to_screaming_snake_case(non_snake_case_string: &str) -> String {
     to_case_snake_like(non_snake_case_string, "_", "upper")
 }
 
-/// Determines of a `String` is `SCREAMING_SNAKE_CASE`
+/// Determines of a `&str` is `SCREAMING_SNAKE_CASE`
 ///
 /// ```
 ///     use inflector::cases::screamingsnakecase::is_screaming_snake_case;
-///     let mock_string: String = "Foo bar string that is really really long".to_string();
+///     let mock_string: &str = "Foo bar string that is really really long";
 ///     let asserted_bool: bool = is_screaming_snake_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::screamingsnakecase::is_screaming_snake_case;
-///     let mock_string: String = "foo-bar-string-that-is-really-really-long".to_string();
+///     let mock_string: &str = "foo-bar-string-that-is-really-really-long";
 ///     let asserted_bool: bool = is_screaming_snake_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::screamingsnakecase::is_screaming_snake_case;
-///     let mock_string: String = "FooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "FooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_screaming_snake_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::screamingsnakecase::is_screaming_snake_case;
-///     let mock_string: String = "Foo Bar Is A Really Really Long String".to_string();
+///     let mock_string: &str = "Foo Bar Is A Really Really Long String";
 ///     let asserted_bool: bool = is_screaming_snake_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::screamingsnakecase::is_screaming_snake_case;
-///     let mock_string: String = "fooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "fooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_screaming_snake_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::screamingsnakecase::is_screaming_snake_case;
-///     let mock_string: String = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG".to_string();
+///     let mock_string: &str = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG";
 ///     let asserted_bool: bool = is_screaming_snake_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::screamingsnakecase::is_screaming_snake_case;
-///     let mock_string: String = "FOO_BAR1_STRING_THAT_IS_REALLY_REALLY_LONG".to_string();
+///     let mock_string: &str = "FOO_BAR1_STRING_THAT_IS_REALLY_REALLY_LONG";
 ///     let asserted_bool: bool = is_screaming_snake_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::screamingsnakecase::is_screaming_snake_case;
-///     let mock_string: String = "FOO_BAR_1_STRING_THAT_IS_REALLY_REALLY_LONG".to_string();
+///     let mock_string: &str = "FOO_BAR_1_STRING_THAT_IS_REALLY_REALLY_LONG";
 ///     let asserted_bool: bool = is_screaming_snake_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
 /// ```
-pub fn is_screaming_snake_case(test_string: String) -> bool {
+pub fn is_screaming_snake_case(test_string: &str) -> bool {
     test_string == to_screaming_snake_case(test_string.clone())
 }
 
@@ -132,12 +132,12 @@ mod tests {
 
     #[bench]
     fn bench_screaming_snake(b: &mut Bencher) {
-        b.iter(|| super::to_screaming_snake_case("Foo bar".to_string()));
+        b.iter(|| super::to_screaming_snake_case("Foo bar"));
     }
 
     #[bench]
     fn bench_is_screaming_snake(b: &mut Bencher) {
-        b.iter(|| super::is_screaming_snake_case("Foo bar".to_string()));
+        b.iter(|| super::is_screaming_snake_case("Foo bar"));
     }
 }
 

--- a/src/cases/sentencecase/mod.rs
+++ b/src/cases/sentencecase/mod.rs
@@ -1,10 +1,10 @@
 #![deny(warnings)]
 use cases::case::*;
-/// Converts a `String` to `Sentence case` `String`
+/// Converts a `&str` to `Sentence case` `String`
 ///
 /// ```
 ///     use inflector::cases::sentencecase::to_sentence_case;
-///     let mock_string: String = "Foo bar".to_string();
+///     let mock_string: &str = "Foo bar";
 ///     let expected_string: String = "Foo bar".to_string();
 ///     let asserted_string: String = to_sentence_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -12,7 +12,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::sentencecase::to_sentence_case;
-///     let mock_string: String = "FooBar".to_string();
+///     let mock_string: &str = "FooBar";
 ///     let expected_string: String = "Foo bar".to_string();
 ///     let asserted_string: String = to_sentence_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -20,7 +20,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::sentencecase::to_sentence_case;
-///     let mock_string: String = "fooBar".to_string();
+///     let mock_string: &str = "fooBar";
 ///     let expected_string: String = "Foo bar".to_string();
 ///     let asserted_string: String = to_sentence_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -28,7 +28,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::sentencecase::to_sentence_case;
-///     let mock_string: String = "FOO_BAR".to_string();
+///     let mock_string: &str = "FOO_BAR";
 ///     let expected_string: String = "Foo bar".to_string();
 ///     let asserted_string: String = to_sentence_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -36,7 +36,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::sentencecase::to_sentence_case;
-///     let mock_string: String = "foo_bar".to_string();
+///     let mock_string: &str = "foo_bar";
 ///     let expected_string: String = "Foo bar".to_string();
 ///     let asserted_string: String = to_sentence_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -44,13 +44,13 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::sentencecase::to_sentence_case;
-///     let mock_string: String = "foo-bar".to_string();
+///     let mock_string: &str = "foo-bar";
 ///     let expected_string: String = "Foo bar".to_string();
 ///     let asserted_string: String = to_sentence_case(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_sentence_case(non_sentence_case_string: String) -> String {
+pub fn to_sentence_case(non_sentence_case_string: &str) -> String {
     let options = CamelOptions {
         new_word: true,
         last_char: ' ',
@@ -61,72 +61,72 @@ pub fn to_sentence_case(non_sentence_case_string: String) -> String {
     };
     to_case_camel_like(non_sentence_case_string, options)
 }
-/// Determines of a `String` is `Sentence case`
+/// Determines of a `&str` is `Sentence case`
 ///
 /// ```
 ///     use inflector::cases::sentencecase::is_sentence_case;
-///     let mock_string: String = "foo-bar-string-that-is-really-really-long".to_string();
+///     let mock_string: &str = "foo-bar-string-that-is-really-really-long";
 ///     let asserted_bool: bool = is_sentence_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::sentencecase::is_sentence_case;
-///     let mock_string: String = "FooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "FooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_sentence_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::sentencecase::is_sentence_case;
-///     let mock_string: String = "fooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "fooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_sentence_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::sentencecase::is_sentence_case;
-///     let mock_string: String = "Foo Bar Is A Really Really Long String".to_string();
+///     let mock_string: &str = "Foo Bar Is A Really Really Long String";
 ///     let asserted_bool: bool = is_sentence_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::sentencecase::is_sentence_case;
-///     let mock_string: String = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG".to_string();
+///     let mock_string: &str = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG";
 ///     let asserted_bool: bool = is_sentence_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::sentencecase::is_sentence_case;
-///     let mock_string: String = "foo_bar_string_that_is_really_really_long".to_string();
+///     let mock_string: &str = "foo_bar_string_that_is_really_really_long";
 ///     let asserted_bool: bool = is_sentence_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::sentencecase::is_sentence_case;
-///     let mock_string: String = "Foo".to_string();
+///     let mock_string: &str = "Foo";
 ///     let asserted_bool: bool = is_sentence_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::sentencecase::is_sentence_case;
-///     let mock_string: String = "foo".to_string();
+///     let mock_string: &str = "foo";
 ///     let asserted_bool: bool = is_sentence_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::sentencecase::is_sentence_case;
-///     let mock_string: String = "Foo bar string that is really really long".to_string();
+///     let mock_string: &str = "Foo bar string that is really really long";
 ///     let asserted_bool: bool = is_sentence_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
 /// ```
-pub fn is_sentence_case(test_string: String) -> bool {
+pub fn is_sentence_case(test_string: &str) -> bool {
     test_string == to_sentence_case(test_string.clone())
 }
 
@@ -137,17 +137,17 @@ mod tests {
 
     #[bench]
     fn bench_sentence(b: &mut Bencher) {
-        b.iter(|| super::to_sentence_case("Foo BAR".to_string()));
+        b.iter(|| super::to_sentence_case("Foo BAR"));
     }
 
     #[bench]
     fn bench_is_sentence(b: &mut Bencher) {
-        b.iter(|| super::is_sentence_case("Foo bar".to_string()));
+        b.iter(|| super::is_sentence_case("Foo bar"));
     }
 
     #[bench]
     fn bench_sentence_from_snake(b: &mut Bencher) {
-        b.iter(|| super::to_sentence_case("foo_bar".to_string()));
+        b.iter(|| super::to_sentence_case("foo_bar"));
     }
 }
 

--- a/src/cases/snakecase/mod.rs
+++ b/src/cases/snakecase/mod.rs
@@ -1,10 +1,10 @@
 #![deny(warnings)]
 use cases::case::*;
-/// Converts a `String` to `snake_case` `String`
+/// Converts a `&str` to `snake_case` `String`
 ///
 /// ```
 ///     use inflector::cases::snakecase::to_snake_case;
-///     let mock_string: String = "foo_bar".to_string();
+///     let mock_string: &str = "foo_bar";
 ///     let expected_string: String = "foo_bar".to_string();
 ///     let asserted_string: String = to_snake_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -12,7 +12,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::to_snake_case;
-///     let mock_string: String = "HTTP Foo bar".to_string();
+///     let mock_string: &str = "HTTP Foo bar";
 ///     let expected_string: String = "http_foo_bar".to_string();
 ///     let asserted_string: String = to_snake_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -20,7 +20,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::to_snake_case;
-///     let mock_string: String = "HTTPFooBar".to_string();
+///     let mock_string: &str = "HTTPFooBar";
 ///     let expected_string: String = "http_foo_bar".to_string();
 ///     let asserted_string: String = to_snake_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -28,7 +28,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::to_snake_case;
-///     let mock_string: String = "Foo bar".to_string();
+///     let mock_string: &str = "Foo bar";
 ///     let expected_string: String = "foo_bar".to_string();
 ///     let asserted_string: String = to_snake_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -36,7 +36,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::to_snake_case;
-///     let mock_string: String = "Foo Bar".to_string();
+///     let mock_string: &str = "Foo Bar";
 ///     let expected_string: String = "foo_bar".to_string();
 ///     let asserted_string: String = to_snake_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -44,7 +44,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::to_snake_case;
-///     let mock_string: String = "FooBar".to_string();
+///     let mock_string: &str = "FooBar";
 ///     let expected_string: String = "foo_bar".to_string();
 ///     let asserted_string: String = to_snake_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -52,7 +52,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::to_snake_case;
-///     let mock_string: String = "FOO_BAR".to_string();
+///     let mock_string: &str = "FOO_BAR";
 ///     let expected_string: String = "foo_bar".to_string();
 ///     let asserted_string: String = to_snake_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -60,7 +60,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::to_snake_case;
-///     let mock_string: String = "fooBar".to_string();
+///     let mock_string: &str = "fooBar";
 ///     let expected_string: String = "foo_bar".to_string();
 ///     let asserted_string: String = to_snake_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -68,82 +68,82 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::to_snake_case;
-///     let mock_string: String = "fooBar3".to_string();
+///     let mock_string: &str = "fooBar3";
 ///     let expected_string: String = "foo_bar_3".to_string();
 ///     let asserted_string: String = to_snake_case(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_snake_case(non_snake_case_string: String) -> String {
+pub fn to_snake_case(non_snake_case_string: &str) -> String {
     to_case_snake_like(non_snake_case_string, "_", "lower")
 }
 
-/// Determines of a `String` is `snake_case`
+/// Determines of a `&str` is `snake_case`
 ///
 /// ```
 ///     use inflector::cases::snakecase::is_snake_case;
-///     let mock_string: String = "Foo bar string that is really really long".to_string();
+///     let mock_string: &str = "Foo bar string that is really really long";
 ///     let asserted_bool: bool = is_snake_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::is_snake_case;
-///     let mock_string: String = "foo-bar-string-that-is-really-really-long".to_string();
+///     let mock_string: &str = "foo-bar-string-that-is-really-really-long";
 ///     let asserted_bool: bool = is_snake_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::is_snake_case;
-///     let mock_string: String = "FooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "FooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_snake_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::is_snake_case;
-///     let mock_string: String = "Foo Bar Is A Really Really Long String".to_string();
+///     let mock_string: &str = "Foo Bar Is A Really Really Long String";
 ///     let asserted_bool: bool = is_snake_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::is_snake_case;
-///     let mock_string: String = "FOO_BAR_IS_A_REALLY_REALLY_LONG_STRING".to_string();
+///     let mock_string: &str = "FOO_BAR_IS_A_REALLY_REALLY_LONG_STRING";
 ///     let asserted_bool: bool = is_snake_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::is_snake_case;
-///     let mock_string: String = "fooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "fooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_snake_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::is_snake_case;
-///     let mock_string: String = "foo_bar_string_that_is_really_really_long".to_string();
+///     let mock_string: &str = "foo_bar_string_that_is_really_really_long";
 ///     let asserted_bool: bool = is_snake_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::is_snake_case;
-///     let mock_string: String = "foo_bar1_string_that_is_really_really_long".to_string();
+///     let mock_string: &str = "foo_bar1_string_that_is_really_really_long";
 ///     let asserted_bool: bool = is_snake_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::snakecase::is_snake_case;
-///     let mock_string: String = "foo_bar_1_string_that_is_really_really_long".to_string();
+///     let mock_string: &str = "foo_bar_1_string_that_is_really_really_long";
 ///     let asserted_bool: bool = is_snake_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
 /// ```
-pub fn is_snake_case(test_string: String) -> bool {
+pub fn is_snake_case(test_string: &str) -> bool {
     test_string == to_snake_case(test_string.clone())
 }
 
@@ -154,22 +154,22 @@ mod tests {
 
     #[bench]
     fn bench_snake_from_title(b: &mut Bencher) {
-        b.iter(|| super::to_snake_case("Foo bar".to_string()));
+        b.iter(|| super::to_snake_case("Foo bar"));
     }
 
     #[bench]
     fn bench_snake_from_camel(b: &mut Bencher) {
-        b.iter(|| super::to_snake_case("fooBar".to_string()));
+        b.iter(|| super::to_snake_case("fooBar"));
     }
 
     #[bench]
     fn bench_snake_from_snake(b: &mut Bencher) {
-        b.iter(|| super::to_snake_case("foo_bar_bar_bar".to_string()));
+        b.iter(|| super::to_snake_case("foo_bar_bar_bar"));
     }
 
     #[bench]
     fn bench_is_snake(b: &mut Bencher) {
-        b.iter(|| super::is_snake_case("Foo bar".to_string()));
+        b.iter(|| super::is_snake_case("Foo bar"));
     }
 }
 

--- a/src/cases/tablecase/mod.rs
+++ b/src/cases/tablecase/mod.rs
@@ -4,11 +4,11 @@ use string::pluralize::to_plural;
 #[cfg(feature = "heavyweight")]
 use cases::case::*;
 #[cfg(feature = "heavyweight")]
-/// Converts a `String` to `table-case` `String`
+/// Converts a `&str` to `table-case` `String`
 ///
 /// ```
 /// use inflector::cases::tablecase::to_table_case;
-/// let mock_string: String = "foo-bar".to_string();
+/// let mock_string: &str = "foo-bar";
 /// let expected_string: String = "foo_bars".to_string();
 /// let asserted_string: String = to_table_case(mock_string);
 /// assert!(asserted_string == expected_string);
@@ -16,7 +16,7 @@ use cases::case::*;
 ///
 /// ```
 /// use inflector::cases::tablecase::to_table_case;
-/// let mock_string: String = "FOO_BAR".to_string();
+/// let mock_string: &str = "FOO_BAR";
 /// let expected_string: String = "foo_bars".to_string();
 /// let asserted_string: String = to_table_case(mock_string);
 /// assert!(asserted_string == expected_string);
@@ -24,7 +24,7 @@ use cases::case::*;
 ///
 /// ```
 /// use inflector::cases::tablecase::to_table_case;
-/// let mock_string: String = "foo_bar".to_string();
+/// let mock_string: &str = "foo_bar";
 /// let expected_string: String = "foo_bars".to_string();
 /// let asserted_string: String = to_table_case(mock_string);
 /// assert!(asserted_string == expected_string);
@@ -32,7 +32,7 @@ use cases::case::*;
 ///
 /// ```
 /// use inflector::cases::tablecase::to_table_case;
-/// let mock_string: String = "Foo Bar".to_string();
+/// let mock_string: &str = "Foo Bar";
 /// let expected_string: String = "foo_bars".to_string();
 /// let asserted_string: String = to_table_case(mock_string);
 /// assert!(asserted_string == expected_string);
@@ -40,7 +40,7 @@ use cases::case::*;
 ///
 /// ```
 /// use inflector::cases::tablecase::to_table_case;
-/// let mock_string: String = "Foo bar".to_string();
+/// let mock_string: &str = "Foo bar";
 /// let expected_string: String = "foo_bars".to_string();
 /// let asserted_string: String = to_table_case(mock_string);
 /// assert!(asserted_string == expected_string);
@@ -48,7 +48,7 @@ use cases::case::*;
 ///
 /// ```
 /// use inflector::cases::tablecase::to_table_case;
-/// let mock_string: String = "FooBar".to_string();
+/// let mock_string: &str = "FooBar";
 /// let expected_string: String = "foo_bars".to_string();
 /// let asserted_string: String = to_table_case(mock_string);
 /// assert!(asserted_string == expected_string);
@@ -56,76 +56,76 @@ use cases::case::*;
 ///
 /// ```
 /// use inflector::cases::tablecase::to_table_case;
-/// let mock_string: String = "fooBar".to_string();
+/// let mock_string: &str = "fooBar";
 /// let expected_string: String = "foo_bars".to_string();
 /// let asserted_string: String = to_table_case(mock_string);
 /// assert!(asserted_string == expected_string);
 /// ```
-pub fn to_table_case(non_table_case_string: String) -> String {
+pub fn to_table_case(non_table_case_string: &str) -> String {
     let snaked: String = to_case_snake_like(non_table_case_string, "_", "lower");
     let split: (&str, &str) = snaked.split_at(snaked.rfind('_').unwrap_or(0));
-    format!("{}{}", split.0, to_plural(split.1.to_string()))
+    format!("{}{}", split.0, to_plural(split.1))
 }
 
 #[cfg(feature = "heavyweight")]
-/// Determines if a `String` is `table-case`
+/// Determines if a `&str` is `table-case`
 ///
 /// ```
 ///     use inflector::cases::tablecase::is_table_case;
-///     let mock_string: String = "foo_bar_strings".to_string();
+///     let mock_string: &str = "foo_bar_strings";
 ///     let asserted_bool: bool = is_table_case(mock_string);
 ///     assert!(asserted_bool == true);
 /// ```
 ///
 /// ```
 ///     use inflector::cases::tablecase::is_table_case;
-///     let mock_string: String = "foo-bar-string-that-is-really-really-long".to_string();
+///     let mock_string: &str = "foo-bar-string-that-is-really-really-long";
 ///     let asserted_bool: bool = is_table_case(mock_string);
 ///     assert!(asserted_bool == false);
 /// ```
 ///
 /// ```
 ///     use inflector::cases::tablecase::is_table_case;
-///     let mock_string: String = "FooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "FooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_table_case(mock_string);
 ///     assert!(asserted_bool == false);
 /// ```
 ///
 /// ```
 ///     use inflector::cases::tablecase::is_table_case;
-///     let mock_string: String = "fooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "fooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_table_case(mock_string);
 ///     assert!(asserted_bool == false);
 /// ```
 ///
 /// ```
 ///     use inflector::cases::tablecase::is_table_case;
-///     let mock_string: String = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG".to_string();
+///     let mock_string: &str = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG";
 ///     let asserted_bool: bool = is_table_case(mock_string);
 ///     assert!(asserted_bool == false);
 /// ```
 ///
 /// ```
 ///     use inflector::cases::tablecase::is_table_case;
-///     let mock_string: String = "foo_bar_string_that_is_really_really_long".to_string();
+///     let mock_string: &str = "foo_bar_string_that_is_really_really_long";
 ///     let asserted_bool: bool = is_table_case(mock_string);
 ///     assert!(asserted_bool == false);
 /// ```
 ///
 /// ```
 ///     use inflector::cases::tablecase::is_table_case;
-///     let mock_string: String = "Foo bar string that is really really long".to_string();
+///     let mock_string: &str = "Foo bar string that is really really long";
 ///     let asserted_bool: bool = is_table_case(mock_string);
 ///     assert!(asserted_bool == false);
 /// ```
 ///
 /// ```
 ///     use inflector::cases::tablecase::is_table_case;
-///     let mock_string: String = "Foo Bar Is A Really Really Long String".to_string();
+///     let mock_string: &str = "Foo Bar Is A Really Really Long String";
 ///     let asserted_bool: bool = is_table_case(mock_string);
 ///     assert!(asserted_bool == false);
 /// ```
-pub fn is_table_case(test_string: String) -> bool {
+pub fn is_table_case(test_string: &str) -> bool {
     test_string.clone() == to_table_case(test_string)
 }
 
@@ -137,12 +137,12 @@ mod tests {
 
     #[bench]
     fn bench_table_case(b: &mut Bencher) {
-        b.iter(|| super::to_table_case("Foo bar".to_string()));
+        b.iter(|| super::to_table_case("Foo bar"));
     }
 
     #[bench]
     fn bench_is_table_case(b: &mut Bencher) {
-        b.iter(|| super::is_table_case("Foo bar".to_string()));
+        b.iter(|| super::is_table_case("Foo bar"));
     }
 }
 

--- a/src/cases/titlecase/mod.rs
+++ b/src/cases/titlecase/mod.rs
@@ -1,10 +1,10 @@
 #![deny(warnings)]
 use cases::case::*;
-/// Converts a `String` to `Title Case` `String`
+/// Converts a `&str` to `Title Case` `String`
 ///
 /// ```
 ///     use inflector::cases::titlecase::to_title_case;
-///     let mock_string: String = "Foo bar".to_string();
+///     let mock_string: &str = "Foo bar";
 ///     let expected_string: String = "Foo Bar".to_string();
 ///     let asserted_string: String = to_title_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -12,7 +12,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::titlecase::to_title_case;
-///     let mock_string: String = "FooBar".to_string();
+///     let mock_string: &str = "FooBar";
 ///     let expected_string: String = "Foo Bar".to_string();
 ///     let asserted_string: String = to_title_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -20,7 +20,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::titlecase::to_title_case;
-///     let mock_string: String = "fooBar".to_string();
+///     let mock_string: &str = "fooBar";
 ///     let expected_string: String = "Foo Bar".to_string();
 ///     let asserted_string: String = to_title_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -28,7 +28,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::titlecase::to_title_case;
-///     let mock_string: String = "FOO_BAR".to_string();
+///     let mock_string: &str = "FOO_BAR";
 ///     let expected_string: String = "Foo Bar".to_string();
 ///     let asserted_string: String = to_title_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -36,7 +36,7 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::titlecase::to_title_case;
-///     let mock_string: String = "foo_bar".to_string();
+///     let mock_string: &str = "foo_bar";
 ///     let expected_string: String = "Foo Bar".to_string();
 ///     let asserted_string: String = to_title_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -44,13 +44,13 @@ use cases::case::*;
 /// ```
 /// ```
 ///     use inflector::cases::titlecase::to_title_case;
-///     let mock_string: String = "foo-bar".to_string();
+///     let mock_string: &str = "foo-bar";
 ///     let expected_string: String = "Foo Bar".to_string();
 ///     let asserted_string: String = to_title_case(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_title_case(non_title_case_string: String) -> String {
+pub fn to_title_case(non_title_case_string: &str) -> String {
     let options = CamelOptions {
         new_word: true,
         last_char: ' ',
@@ -62,65 +62,65 @@ pub fn to_title_case(non_title_case_string: String) -> String {
     to_case_camel_like(non_title_case_string, options)
 }
 
-/// Determines if a `String` is `Title Case`
+/// Determines if a `&str` is `Title Case`
 ///
 /// ```
 ///     use inflector::cases::titlecase::is_title_case;
-///     let mock_string: String = "foo-bar-string-that-is-really-really-long".to_string();
+///     let mock_string: &str = "foo-bar-string-that-is-really-really-long";
 ///     let asserted_bool: bool = is_title_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::titlecase::is_title_case;
-///     let mock_string: String = "FooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "FooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_title_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::titlecase::is_title_case;
-///     let mock_string: String = "fooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "fooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_title_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::titlecase::is_title_case;
-///     let mock_string: String = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG".to_string();
+///     let mock_string: &str = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG";
 ///     let asserted_bool: bool = is_title_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::titlecase::is_title_case;
-///     let mock_string: String = "foo_bar_string_that_is_really_really_long".to_string();
+///     let mock_string: &str = "foo_bar_string_that_is_really_really_long";
 ///     let asserted_bool: bool = is_title_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::titlecase::is_title_case;
-///     let mock_string: String = "Foo bar string that is really really long".to_string();
+///     let mock_string: &str = "Foo bar string that is really really long";
 ///     let asserted_bool: bool = is_title_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::titlecase::is_title_case;
-///     let mock_string: String = "foo".to_string();
+///     let mock_string: &str = "foo";
 ///     let asserted_bool: bool = is_title_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::cases::titlecase::is_title_case;
-///     let mock_string: String = "Foo Bar String That Is Really Really Long".to_string();
+///     let mock_string: &str = "Foo Bar String That Is Really Really Long";
 ///     let asserted_bool: bool = is_title_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
 /// ```
-pub fn is_title_case(test_string: String) -> bool {
+pub fn is_title_case(test_string: &str) -> bool {
     test_string == to_title_case(test_string.clone())
 }
 
@@ -131,17 +131,17 @@ mod tests {
 
     #[bench]
     fn bench_title(b: &mut Bencher) {
-        b.iter(|| super::to_title_case("Foo BAR".to_string()));
+        b.iter(|| super::to_title_case("Foo BAR"));
     }
 
     #[bench]
     fn bench_is_title(b: &mut Bencher) {
-        b.iter(|| super::is_title_case("Foo bar".to_string()));
+        b.iter(|| super::is_title_case("Foo bar"));
     }
 
     #[bench]
     fn bench_title_from_snake(b: &mut Bencher) {
-        b.iter(|| super::to_title_case("foo_bar".to_string()));
+        b.iter(|| super::to_title_case("foo_bar"));
     }
 }
 

--- a/src/cases/traincase/mod.rs
+++ b/src/cases/traincase/mod.rs
@@ -1,10 +1,10 @@
 #![deny(warnings)]
 use cases::case::*;
-/// Determines if a `String` is `Train-Case`
+/// Determines if a `&str` is `Train-Case`
 ///
 /// ```
 ///     use inflector::cases::traincase::is_train_case;
-///     let mock_string: String = "Foo-Bar-String-That-Is-Really-Really-Long".to_string();
+///     let mock_string: &str = "Foo-Bar-String-That-Is-Really-Really-Long";
 ///     let asserted_bool: bool = is_train_case(mock_string);
 ///     assert!(asserted_bool == true);
 ///
@@ -12,7 +12,7 @@ use cases::case::*;
 ///
 /// ```
 ///     use inflector::cases::traincase::is_train_case;
-///     let mock_string: String = "foo-bar-string-that-is-really-really-long".to_string();
+///     let mock_string: &str = "foo-bar-string-that-is-really-really-long";
 ///     let asserted_bool: bool = is_train_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -20,7 +20,7 @@ use cases::case::*;
 ///
 /// ```
 ///     use inflector::cases::traincase::is_train_case;
-///     let mock_string: String = "FooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "FooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_train_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -28,7 +28,7 @@ use cases::case::*;
 ///
 /// ```
 ///     use inflector::cases::traincase::is_train_case;
-///     let mock_string: String = "fooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "fooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_train_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -36,7 +36,7 @@ use cases::case::*;
 ///
 /// ```
 ///     use inflector::cases::traincase::is_train_case;
-///     let mock_string: String = "foo_bar_string_that_is_really_really_long".to_string();
+///     let mock_string: &str = "foo_bar_string_that_is_really_really_long";
 ///     let asserted_bool: bool = is_train_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -44,7 +44,7 @@ use cases::case::*;
 ///
 /// ```
 ///     use inflector::cases::traincase::is_train_case;
-///     let mock_string: String = "Foo bar string that is really really long".to_string();
+///     let mock_string: &str = "Foo bar string that is really really long";
 ///     let asserted_bool: bool = is_train_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
@@ -52,21 +52,21 @@ use cases::case::*;
 ///
 /// ```
 ///     use inflector::cases::traincase::is_train_case;
-///     let mock_string: String = "Foo Bar Is A Really Really Long String".to_string();
+///     let mock_string: &str = "Foo Bar Is A Really Really Long String";
 ///     let asserted_bool: bool = is_train_case(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
-pub fn is_train_case(test_string: String) -> bool {
+pub fn is_train_case(test_string: &str) -> bool {
     test_string == to_train_case(test_string.clone())
 }
 
 
-/// Converts a `String` to `Train-Case` `String`
+/// Converts a `&str` to `Train-Case` `String`
 ///
 /// ```
 ///     use inflector::cases::traincase::to_train_case;
-///     let mock_string: String = "foo-bar".to_string();
+///     let mock_string: &str = "foo-bar";
 ///     let expected_string: String = "Foo-Bar".to_string();
 ///     let asserted_string: String = to_train_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -75,7 +75,7 @@ pub fn is_train_case(test_string: String) -> bool {
 ///
 /// ```
 ///     use inflector::cases::traincase::to_train_case;
-///     let mock_string: String = "FOO_BAR".to_string();
+///     let mock_string: &str = "FOO_BAR";
 ///     let expected_string: String = "Foo-Bar".to_string();
 ///     let asserted_string: String = to_train_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -84,7 +84,7 @@ pub fn is_train_case(test_string: String) -> bool {
 ///
 /// ```
 ///     use inflector::cases::traincase::to_train_case;
-///     let mock_string: String = "foo_bar".to_string();
+///     let mock_string: &str = "foo_bar";
 ///     let expected_string: String = "Foo-Bar".to_string();
 ///     let asserted_string: String = to_train_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -93,7 +93,7 @@ pub fn is_train_case(test_string: String) -> bool {
 ///
 /// ```
 ///     use inflector::cases::traincase::to_train_case;
-///     let mock_string: String = "Foo Bar".to_string();
+///     let mock_string: &str = "Foo Bar";
 ///     let expected_string: String = "Foo-Bar".to_string();
 ///     let asserted_string: String = to_train_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -102,7 +102,7 @@ pub fn is_train_case(test_string: String) -> bool {
 ///
 /// ```
 ///     use inflector::cases::traincase::to_train_case;
-///     let mock_string: String = "Foo bar".to_string();
+///     let mock_string: &str = "Foo bar";
 ///     let expected_string: String = "Foo-Bar".to_string();
 ///     let asserted_string: String = to_train_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -111,7 +111,7 @@ pub fn is_train_case(test_string: String) -> bool {
 ///
 /// ```
 ///     use inflector::cases::traincase::to_train_case;
-///     let mock_string: String = "FooBar".to_string();
+///     let mock_string: &str = "FooBar";
 ///     let expected_string: String = "Foo-Bar".to_string();
 ///     let asserted_string: String = to_train_case(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -120,13 +120,13 @@ pub fn is_train_case(test_string: String) -> bool {
 ///
 /// ```
 ///     use inflector::cases::traincase::to_train_case;
-///     let mock_string: String = "fooBar".to_string();
+///     let mock_string: &str = "fooBar";
 ///     let expected_string: String = "Foo-Bar".to_string();
 ///     let asserted_string: String = to_train_case(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_train_case(non_train_case_string: String) -> String {
+pub fn to_train_case(non_train_case_string: &str) -> String {
     let options = CamelOptions {
         new_word: true,
         last_char: ' ',
@@ -145,17 +145,17 @@ mod tests {
 
     #[bench]
     fn bench_train(b: &mut Bencher) {
-        b.iter(|| super::to_train_case("Foo bar".to_string()));
+        b.iter(|| super::to_train_case("Foo bar"));
     }
 
     #[bench]
     fn bench_is_train(b: &mut Bencher) {
-        b.iter(|| super::is_train_case("Foo bar".to_string()));
+        b.iter(|| super::is_train_case("Foo bar"));
     }
 
     #[bench]
     fn bench_train_from_snake(b: &mut Bencher) {
-        b.iter(|| super::to_train_case("test_test_test".to_string()));
+        b.iter(|| super::to_train_case("test_test_test"));
     }
 }
 define_test_group!(train_tests, to_train_case, traincase, "Foo-Bar", "Foo-Bars");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,18 @@ macro_rules! define_implementations {
         $(
             #[inline]
             fn $imp_trait(&$slf) -> $typ {
-                $imp_trait($slf.to_string())
+                $imp_trait($slf)
+            }
+        )*
+    }
+}
+
+macro_rules! define_number_implementations {
+    ( $slf:ident; $($imp_trait:ident => $typ:ident), *) => {
+        $(
+            #[inline]
+            fn $imp_trait(&$slf) -> $typ {
+                $imp_trait(&$slf.to_string())
             }
         )*
     }
@@ -169,7 +180,7 @@ macro_rules! define_gated_implementations {
             #[inline]
             #[cfg(feature = "heavyweight")]
             fn $imp_trait(&$slf) -> $typ {
-                $imp_trait($slf.to_string())
+                $imp_trait($slf)
             }
         )*
     }
@@ -220,7 +231,7 @@ macro_rules! implement_number_for {
     ( $trt:ident; $($typ:ident), *) => {
         $(
             impl $trt for $typ {
-                define_implementations![self;
+                define_number_implementations![self;
                     ordinalize => String
                 ];
             }

--- a/src/numbers/deordinalize/mod.rs
+++ b/src/numbers/deordinalize/mod.rs
@@ -1,8 +1,8 @@
-/// Deorginalizes a `String`
+/// Deorginalizes a `&str`
 ///
 /// ```
 ///     use inflector::numbers::deordinalize::deordinalize;
-///     let mock_string: String = "0.1".to_string();
+///     let mock_string: &str = "0.1";
 ///     let expected_string: String = "0.1".to_string();
 ///     let asserted_string: String = deordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -10,7 +10,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::deordinalize::deordinalize;
-///     let mock_string: String = "-1st".to_string();
+///     let mock_string: &str = "-1st";
 ///     let expected_string: String = "-1".to_string();
 ///     let asserted_string: String = deordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -18,7 +18,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::deordinalize::deordinalize;
-///     let mock_string: String = "0th".to_string();
+///     let mock_string: &str = "0th";
 ///     let expected_string: String = "0".to_string();
 ///     let asserted_string: String = deordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -26,7 +26,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::deordinalize::deordinalize;
-///     let mock_string: String = "1st".to_string();
+///     let mock_string: &str = "1st";
 ///     let expected_string: String = "1".to_string();
 ///     let asserted_string: String = deordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -34,7 +34,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::deordinalize::deordinalize;
-///     let mock_string: String = "2nd".to_string();
+///     let mock_string: &str = "2nd";
 ///     let expected_string: String = "2".to_string();
 ///     let asserted_string: String = deordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -42,7 +42,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::deordinalize::deordinalize;
-///     let mock_string: String = "3rd".to_string();
+///     let mock_string: &str = "3rd";
 ///     let expected_string: String = "3".to_string();
 ///     let asserted_string: String = deordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -50,7 +50,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::deordinalize::deordinalize;
-///     let mock_string: String = "9th".to_string();
+///     let mock_string: &str = "9th";
 ///     let expected_string: String = "9".to_string();
 ///     let asserted_string: String = deordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -58,7 +58,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::deordinalize::deordinalize;
-///     let mock_string: String = "12th".to_string();
+///     let mock_string: &str = "12th";
 ///     let expected_string: String = "12".to_string();
 ///     let asserted_string: String = deordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -66,7 +66,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::deordinalize::deordinalize;
-///     let mock_string: String = "12000th".to_string();
+///     let mock_string: &str = "12000th";
 ///     let expected_string: String = "12000".to_string();
 ///     let asserted_string: String = deordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -74,7 +74,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::deordinalize::deordinalize;
-///     let mock_string: String = "12001th".to_string();
+///     let mock_string: &str = "12001th";
 ///     let expected_string: String = "12001".to_string();
 ///     let asserted_string: String = deordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -82,7 +82,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::deordinalize::deordinalize;
-///     let mock_string: String = "12002nd".to_string();
+///     let mock_string: &str = "12002nd";
 ///     let expected_string: String = "12002".to_string();
 ///     let asserted_string: String = deordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -90,7 +90,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::deordinalize::deordinalize;
-///     let mock_string: String = "12003rd".to_string();
+///     let mock_string: &str = "12003rd";
 ///     let expected_string: String = "12003".to_string();
 ///     let asserted_string: String = deordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -98,15 +98,15 @@
 /// ```
 /// ```
 ///     use inflector::numbers::deordinalize::deordinalize;
-///     let mock_string: String = "12004th".to_string();
+///     let mock_string: &str = "12004th";
 ///     let expected_string: String = "12004".to_string();
 ///     let asserted_string: String = deordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn deordinalize(non_ordinalized_string: String) -> String {
+pub fn deordinalize(non_ordinalized_string: &str) -> String {
     if non_ordinalized_string.contains('.') {
-        non_ordinalized_string
+        non_ordinalized_string.to_string()
     } else {
         non_ordinalized_string.trim_right_matches("st")
             .trim_right_matches("nd")

--- a/src/numbers/ordinalize/mod.rs
+++ b/src/numbers/ordinalize/mod.rs
@@ -1,8 +1,8 @@
-/// Orginalizes a `String`
+/// Orginalizes a `&str`
 ///
 /// ```
 ///     use inflector::numbers::ordinalize::ordinalize;
-///     let mock_string: String = "a".to_string();
+///     let mock_string: &str = "a";
 ///     let expected_string: String = "a".to_string();
 ///     let asserted_string: String = ordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -10,7 +10,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::ordinalize::ordinalize;
-///     let mock_string: String = "0.1".to_string();
+///     let mock_string: &str = "0.1";
 ///     let expected_string: String = "0.1".to_string();
 ///     let asserted_string: String = ordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -18,7 +18,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::ordinalize::ordinalize;
-///     let mock_string: String = "-1".to_string();
+///     let mock_string: &str = "-1";
 ///     let expected_string: String = "-1st".to_string();
 ///     let asserted_string: String = ordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -26,7 +26,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::ordinalize::ordinalize;
-///     let mock_string: String = "0".to_string();
+///     let mock_string: &str = "0";
 ///     let expected_string: String = "0th".to_string();
 ///     let asserted_string: String = ordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -34,7 +34,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::ordinalize::ordinalize;
-///     let mock_string: String = "1".to_string();
+///     let mock_string: &str = "1";
 ///     let expected_string: String = "1st".to_string();
 ///     let asserted_string: String = ordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -42,7 +42,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::ordinalize::ordinalize;
-///     let mock_string: String = "2".to_string();
+///     let mock_string: &str = "2";
 ///     let expected_string: String = "2nd".to_string();
 ///     let asserted_string: String = ordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -50,7 +50,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::ordinalize::ordinalize;
-///     let mock_string: String = "3".to_string();
+///     let mock_string: &str = "3";
 ///     let expected_string: String = "3rd".to_string();
 ///     let asserted_string: String = ordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -58,7 +58,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::ordinalize::ordinalize;
-///     let mock_string: String = "9".to_string();
+///     let mock_string: &str = "9";
 ///     let expected_string: String = "9th".to_string();
 ///     let asserted_string: String = ordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -66,7 +66,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::ordinalize::ordinalize;
-///     let mock_string: String = "12".to_string();
+///     let mock_string: &str = "12";
 ///     let expected_string: String = "12th".to_string();
 ///     let asserted_string: String = ordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -74,7 +74,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::ordinalize::ordinalize;
-///     let mock_string: String = "12000".to_string();
+///     let mock_string: &str = "12000";
 ///     let expected_string: String = "12000th".to_string();
 ///     let asserted_string: String = ordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -82,7 +82,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::ordinalize::ordinalize;
-///     let mock_string: String = "12001".to_string();
+///     let mock_string: &str = "12001";
 ///     let expected_string: String = "12001st".to_string();
 ///     let asserted_string: String = ordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -90,7 +90,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::ordinalize::ordinalize;
-///     let mock_string: String = "12002".to_string();
+///     let mock_string: &str = "12002";
 ///     let expected_string: String = "12002nd".to_string();
 ///     let asserted_string: String = ordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -98,7 +98,7 @@
 /// ```
 /// ```
 ///     use inflector::numbers::ordinalize::ordinalize;
-///     let mock_string: String = "12003".to_string();
+///     let mock_string: &str = "12003";
 ///     let expected_string: String = "12003rd".to_string();
 ///     let asserted_string: String = ordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -106,23 +106,23 @@
 /// ```
 /// ```
 ///     use inflector::numbers::ordinalize::ordinalize;
-///     let mock_string: String = "12004".to_string();
+///     let mock_string: &str = "12004";
 ///     let expected_string: String = "12004th".to_string();
 ///     let asserted_string: String = ordinalize(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn ordinalize(non_ordinalized_string: String) -> String {
+pub fn ordinalize(non_ordinalized_string: &str) -> String {
     let chars: Vec<char> = non_ordinalized_string.clone().chars().collect();
     let last_number: char = chars[chars.len() - 1];
     if is_ordinalizable(last_number) {
-        return non_ordinalized_string;
+        return non_ordinalized_string.to_string();
     }
     if chars.len() > 1 {
         if second_last_number_is_one(chars) {
             return format!("{}{}", non_ordinalized_string, "th");
-        } else if string_contains_decimal(non_ordinalized_string.clone()) {
-            return non_ordinalized_string;
+        } else if string_contains_decimal(non_ordinalized_string.to_string()) {
+            return non_ordinalized_string.to_string();
         }
     }
     match last_number {

--- a/src/string/deconstantize/mod.rs
+++ b/src/string/deconstantize/mod.rs
@@ -2,11 +2,11 @@
 use cases::classcase::to_class_case;
 
 #[cfg(feature = "heavyweight")]
-/// Deconstantizes a `String`
+/// Deconstantizes a `&str`
 ///
 /// ```
 ///     use inflector::string::deconstantize::deconstantize;
-///     let mock_string: String = "Bar".to_string();
+///     let mock_string: &str = "Bar";
 ///     let expected_string: String = "".to_string();
 ///     let asserted_string: String = deconstantize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -14,7 +14,7 @@ use cases::classcase::to_class_case;
 /// ```
 /// ```
 ///     use inflector::string::deconstantize::deconstantize;
-///     let mock_string: String = "::Bar".to_string();
+///     let mock_string: &str = "::Bar";
 ///     let expected_string: String = "".to_string();
 ///     let asserted_string: String = deconstantize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -22,7 +22,7 @@ use cases::classcase::to_class_case;
 /// ```
 /// ```
 ///     use inflector::string::deconstantize::deconstantize;
-///     let mock_string: String = "Foo::Bar".to_string();
+///     let mock_string: &str = "Foo::Bar";
 ///     let expected_string: String = "Foo".to_string();
 ///     let asserted_string: String = deconstantize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -30,17 +30,17 @@ use cases::classcase::to_class_case;
 /// ```
 /// ```
 ///     use inflector::string::deconstantize::deconstantize;
-///     let mock_string: String = "Test::Foo::Bar".to_string();
+///     let mock_string: &str = "Test::Foo::Bar";
 ///     let expected_string: String = "Foo".to_string();
 ///     let asserted_string: String = deconstantize(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn deconstantize(non_deconstantized_string: String) -> String {
+pub fn deconstantize(non_deconstantized_string: &str) -> String {
     if non_deconstantized_string.contains("::") {
         let split_string: Vec<&str> = non_deconstantized_string.split("::").collect();
         if split_string.len() > 1 {
-            to_class_case(split_string[split_string.len() - 2].to_string())
+            to_class_case(split_string[split_string.len() - 2])
         } else {
             "".to_string()
         }

--- a/src/string/demodulize/mod.rs
+++ b/src/string/demodulize/mod.rs
@@ -2,11 +2,11 @@
 use cases::classcase::to_class_case;
 
 #[cfg(feature = "heavyweight")]
-/// Demodulize a `String`
+/// Demodulize a `&str`
 ///
 /// ```
 ///     use inflector::string::demodulize::demodulize;
-///     let mock_string: String = "Bar".to_string();
+///     let mock_string: &str = "Bar";
 ///     let expected_string: String = "Bar".to_string();
 ///     let asserted_string: String = demodulize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -14,7 +14,7 @@ use cases::classcase::to_class_case;
 /// ```
 /// ```
 ///     use inflector::string::demodulize::demodulize;
-///     let mock_string: String = "::Bar".to_string();
+///     let mock_string: &str = "::Bar";
 ///     let expected_string: String = "Bar".to_string();
 ///     let asserted_string: String = demodulize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -22,7 +22,7 @@ use cases::classcase::to_class_case;
 /// ```
 /// ```
 ///     use inflector::string::demodulize::demodulize;
-///     let mock_string: String = "Foo::Bar".to_string();
+///     let mock_string: &str = "Foo::Bar";
 ///     let expected_string: String = "Bar".to_string();
 ///     let asserted_string: String = demodulize(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -30,17 +30,17 @@ use cases::classcase::to_class_case;
 /// ```
 /// ```
 ///     use inflector::string::demodulize::demodulize;
-///     let mock_string: String = "Test::Foo::Bar".to_string();
+///     let mock_string: &str = "Test::Foo::Bar";
 ///     let expected_string: String = "Bar".to_string();
 ///     let asserted_string: String = demodulize(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn demodulize(non_demodulize_string: String) -> String {
+pub fn demodulize(non_demodulize_string: &str) -> String {
     if non_demodulize_string.contains("::") {
         let split_string: Vec<&str> = non_demodulize_string.split("::").collect();
-        to_class_case(split_string[split_string.len() - 1].to_string())
+        to_class_case(split_string[split_string.len() - 1])
     } else {
-        non_demodulize_string
+        non_demodulize_string.to_string()
     }
 }

--- a/src/string/pluralize/mod.rs
+++ b/src/string/pluralize/mod.rs
@@ -188,6 +188,7 @@ mod tests {
         axis => axes;
         knife => knives;
         agendum => agenda;
-        elf => elves
+        elf => elves;
+        zoology => zoology
     }
 }

--- a/src/string/pluralize/mod.rs
+++ b/src/string/pluralize/mod.rs
@@ -64,11 +64,11 @@ macro_rules! special_cases{
 }
 
 
-/// Converts a `String` to pluralized `String`
+/// Converts a `&str` to pluralized `String`
 ///
 /// ```
 ///     use inflector::string::pluralize::to_plural;
-///     let mock_string: String = "foo_bar".to_string();
+///     let mock_string: &str = "foo_bar";
 ///     let expected_string: String = "foo_bars".to_string();
 ///     let asserted_string: String = to_plural(mock_string);
 ///     assert_eq!(asserted_string, expected_string);
@@ -76,7 +76,7 @@ macro_rules! special_cases{
 /// ```
 /// ```
 ///     use inflector::string::pluralize::to_plural;
-///     let mock_string: String = "ox".to_string();
+///     let mock_string: &str = "ox";
 ///     let expected_string: String = "oxen".to_string();
 ///     let asserted_string: String = to_plural(mock_string);
 ///     assert_eq!(asserted_string, expected_string);
@@ -84,7 +84,7 @@ macro_rules! special_cases{
 /// ```
 /// ```
 ///     use inflector::string::pluralize::to_plural;
-///     let mock_string: String = "crate".to_string();
+///     let mock_string: &str = "crate";
 ///     let expected_string: String = "crates".to_string();
 ///     let asserted_string: String = to_plural(mock_string);
 ///     assert_eq!(asserted_string, expected_string);
@@ -92,7 +92,7 @@ macro_rules! special_cases{
 /// ```
 /// ```
 ///     use inflector::string::pluralize::to_plural;
-///     let mock_string: String = "boxes".to_string();
+///     let mock_string: &str = "boxes";
 ///     let expected_string: String = "boxes".to_string();
 ///     let asserted_string: String = to_plural(mock_string);
 ///     assert_eq!(asserted_string, expected_string);
@@ -100,7 +100,7 @@ macro_rules! special_cases{
 /// ```
 /// ```
 ///     use inflector::string::pluralize::to_plural;
-///     let mock_string: String = "vengeance".to_string();
+///     let mock_string: &str = "vengeance";
 ///     let expected_string: String = "vengeance".to_string();
 ///     let asserted_string: String = to_plural(mock_string);
 ///     assert_eq!(asserted_string, expected_string);
@@ -108,7 +108,7 @@ macro_rules! special_cases{
 /// ```
 /// ```
 ///     use inflector::string::pluralize::to_plural;
-///     let mock_string: String = "yoga".to_string();
+///     let mock_string: &str = "yoga";
 ///     let expected_string: String = "yoga".to_string();
 ///     let asserted_string: String = to_plural(mock_string);
 ///     assert_eq!(asserted_string, expected_string);
@@ -116,16 +116,16 @@ macro_rules! special_cases{
 /// ```
 /// ```
 ///     use inflector::string::pluralize::to_plural;
-///     let mock_string: String = "geometry".to_string();
+///     let mock_string: &str = "geometry";
 ///     let expected_string: String = "geometries".to_string();
 ///     let asserted_string: String = to_plural(mock_string);
 ///     assert_eq!(asserted_string, expected_string);
 ///
 /// ```
 ///
-pub fn to_plural(non_plural_string: String) -> String {
+pub fn to_plural(non_plural_string: &str) -> String {
     if UNACCONTABLE_WORDS.contains(&non_plural_string.as_ref()) {
-        non_plural_string
+        non_plural_string.to_string()
     } else {
         special_cases![non_plural_string,
             "ox" => "oxen",
@@ -167,7 +167,7 @@ mod tests {
                        fn $singular(){
                            assert_eq!(
                                stringify!($plural),
-                               super::to_plural(stringify!($singular).to_string())
+                               super::to_plural(stringify!($singular))
                                );
                        }
                    }
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn boxes() {
-        assert_eq!("boxes", super::to_plural("box".to_string()));
+        assert_eq!("boxes", super::to_plural("box"));
     }
 
     make_tests!{

--- a/src/string/singularize/mod.rs
+++ b/src/string/singularize/mod.rs
@@ -15,11 +15,11 @@ macro_rules! special_cases{
 }
 
 
-/// Converts a `String` to singularized `String`
+/// Converts a `&str` to singularized `String`
 ///
 /// ```
 ///     use inflector::string::singularize::to_singular;
-///     let mock_string: String = "foo_bars".to_string();
+///     let mock_string: &str = "foo_bars";
 ///     let expected_string: String = "foo_bar".to_string();
 ///     let asserted_string: String = to_singular(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -27,7 +27,7 @@ macro_rules! special_cases{
 /// ```
 /// ```
 ///     use inflector::string::singularize::to_singular;
-///     let mock_string: String = "oxen".to_string();
+///     let mock_string: &str = "oxen";
 ///     let expected_string: String = "ox".to_string();
 ///     let asserted_string: String = to_singular(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -35,7 +35,7 @@ macro_rules! special_cases{
 /// ```
 /// ```
 ///     use inflector::string::singularize::to_singular;
-///     let mock_string: String = "crates".to_string();
+///     let mock_string: &str = "crates";
 ///     let expected_string: String = "crate".to_string();
 ///     let asserted_string: String = to_singular(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -43,7 +43,7 @@ macro_rules! special_cases{
 /// ```
 /// ```
 ///     use inflector::string::singularize::to_singular;
-///     let mock_string: String = "oxen".to_string();
+///     let mock_string: &str = "oxen";
 ///     let expected_string: String = "ox".to_string();
 ///     let asserted_string: String = to_singular(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -51,7 +51,7 @@ macro_rules! special_cases{
 /// ```
 /// ```
 ///     use inflector::string::singularize::to_singular;
-///     let mock_string: String = "boxes".to_string();
+///     let mock_string: &str = "boxes";
 ///     let expected_string: String = "box".to_string();
 ///     let asserted_string: String = to_singular(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -59,7 +59,7 @@ macro_rules! special_cases{
 /// ```
 /// ```
 ///     use inflector::string::singularize::to_singular;
-///     let mock_string: String = "vengeance".to_string();
+///     let mock_string: &str = "vengeance";
 ///     let expected_string: String = "vengeance".to_string();
 ///     let asserted_string: String = to_singular(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -67,16 +67,16 @@ macro_rules! special_cases{
 /// ```
 /// ```
 ///     use inflector::string::singularize::to_singular;
-///     let mock_string: String = "yoga".to_string();
+///     let mock_string: &str = "yoga";
 ///     let expected_string: String = "yoga".to_string();
 ///     let asserted_string: String = to_singular(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
 ///
-pub fn to_singular(non_singular_string: String) -> String {
+pub fn to_singular(non_singular_string: &str) -> String {
     if UNACCONTABLE_WORDS.contains(&non_singular_string.as_ref()) {
-        non_singular_string
+        non_singular_string.to_string()
     } else {
         special_cases![non_singular_string,
             "oxen" => "ox",
@@ -156,15 +156,15 @@ lazy_static!{
 
 #[test]
 fn singularize_ies_suffix() {
-    assert_eq!("reply", to_singular("replies".to_owned()));
-    assert_eq!("lady", to_singular("ladies".to_owned()));
-    assert_eq!("soliloquy", to_singular("soliloquies".to_owned()));
+    assert_eq!("reply", to_singular("replies"));
+    assert_eq!("lady", to_singular("ladies"));
+    assert_eq!("soliloquy", to_singular("soliloquies"));
 }
 
 #[test]
 fn singularize_string_if_a_regex_will_match() {
-    let expected_string: String = "ox".to_string();
-    let asserted_string: String = to_singular("oxen".to_string());
+    let expected_string: String= "ox".to_string();
+    let asserted_string: String = to_singular("oxen");
     assert!(expected_string == asserted_string);
 
 }
@@ -172,7 +172,7 @@ fn singularize_string_if_a_regex_will_match() {
 #[test]
 fn singularize_string_returns_none_option_if_no_match() {
     let expected_string: String = "bacon".to_string();
-    let asserted_string: String = to_singular("bacon".to_string());
+    let asserted_string: String = to_singular("bacon");
 
     assert!(expected_string == asserted_string);
 

--- a/src/suffix/foreignkey/mod.rs
+++ b/src/suffix/foreignkey/mod.rs
@@ -1,10 +1,10 @@
 use cases::snakecase::to_snake_case;
 
-/// Converts a `String` to a `foreign_key`
+/// Converts a `&str` to a `foreign_key`
 ///
 /// ```
 ///     use inflector::suffix::foreignkey::to_foreign_key;
-///     let mock_string: String = "foo_bar".to_string();
+///     let mock_string: &str = "foo_bar";
 ///     let expected_string: String = "foo_bar_id".to_string();
 ///     let asserted_string: String = to_foreign_key(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -12,7 +12,7 @@ use cases::snakecase::to_snake_case;
 /// ```
 /// ```
 ///     use inflector::suffix::foreignkey::to_foreign_key;
-///     let mock_string: String = "Foo bar".to_string();
+///     let mock_string: &str = "Foo bar";
 ///     let expected_string: String = "foo_bar_id".to_string();
 ///     let asserted_string: String = to_foreign_key(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -20,7 +20,7 @@ use cases::snakecase::to_snake_case;
 /// ```
 /// ```
 ///     use inflector::suffix::foreignkey::to_foreign_key;
-///     let mock_string: String = "Foo Bar".to_string();
+///     let mock_string: &str = "Foo Bar";
 ///     let expected_string: String = "foo_bar_id".to_string();
 ///     let asserted_string: String = to_foreign_key(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -28,7 +28,7 @@ use cases::snakecase::to_snake_case;
 /// ```
 /// ```
 ///     use inflector::suffix::foreignkey::to_foreign_key;
-///     let mock_string: String = "Foo::Bar".to_string();
+///     let mock_string: &str = "Foo::Bar";
 ///     let expected_string: String = "bar_id".to_string();
 ///     let asserted_string: String = to_foreign_key(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -36,7 +36,7 @@ use cases::snakecase::to_snake_case;
 /// ```
 /// ```
 ///     use inflector::suffix::foreignkey::to_foreign_key;
-///     let mock_string: String = "Test::Foo::Bar".to_string();
+///     let mock_string: &str = "Test::Foo::Bar";
 ///     let expected_string: String = "bar_id".to_string();
 ///     let asserted_string: String = to_foreign_key(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -44,7 +44,7 @@ use cases::snakecase::to_snake_case;
 /// ```
 /// ```
 ///     use inflector::suffix::foreignkey::to_foreign_key;
-///     let mock_string: String = "FooBar".to_string();
+///     let mock_string: &str = "FooBar";
 ///     let expected_string: String = "foo_bar_id".to_string();
 ///     let asserted_string: String = to_foreign_key(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -52,7 +52,7 @@ use cases::snakecase::to_snake_case;
 /// ```
 /// ```
 ///     use inflector::suffix::foreignkey::to_foreign_key;
-///     let mock_string: String = "fooBar".to_string();
+///     let mock_string: &str = "fooBar";
 ///     let expected_string: String = "foo_bar_id".to_string();
 ///     let asserted_string: String = to_foreign_key(mock_string);
 ///     assert!(asserted_string == expected_string);
@@ -60,22 +60,22 @@ use cases::snakecase::to_snake_case;
 /// ```
 /// ```
 ///     use inflector::suffix::foreignkey::to_foreign_key;
-///     let mock_string: String = "fooBar3".to_string();
+///     let mock_string: &str = "fooBar3";
 ///     let expected_string: String = "foo_bar_3_id".to_string();
 ///     let asserted_string: String = to_foreign_key(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_foreign_key(non_foreign_key_string: String) -> String {
+pub fn to_foreign_key(non_foreign_key_string: &str) -> String {
     if non_foreign_key_string.contains("::") {
         let split_string: Vec<&str> = non_foreign_key_string.split("::").collect();
         safe_convert(split_string[split_string.len() - 1].to_string())
     } else {
-        safe_convert(non_foreign_key_string)
+        safe_convert(non_foreign_key_string.to_string())
     }
 }
 fn safe_convert(safe_string: String) -> String {
-    let snake_cased: String = to_snake_case(safe_string);
+    let snake_cased: String = to_snake_case(&safe_string);
     if snake_cased.ends_with("_id") {
         snake_cased
     } else {
@@ -83,57 +83,57 @@ fn safe_convert(safe_string: String) -> String {
     }
 }
 
-/// Determines if a `String` is a `foreign_key`
+/// Determines if a `&str` is a `foreign_key`
 ///
 /// ```
 ///     use inflector::suffix::foreignkey::is_foreign_key;
-///     let mock_string: String = "Foo bar string that is really really long".to_string();
+///     let mock_string: &str = "Foo bar string that is really really long";
 ///     let asserted_bool: bool = is_foreign_key(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::suffix::foreignkey::is_foreign_key;
-///     let mock_string: String = "foo-bar-string-that-is-really-really-long".to_string();
+///     let mock_string: &str = "foo-bar-string-that-is-really-really-long";
 ///     let asserted_bool: bool = is_foreign_key(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::suffix::foreignkey::is_foreign_key;
-///     let mock_string: String = "FooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "FooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_foreign_key(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::suffix::foreignkey::is_foreign_key;
-///     let mock_string: String = "Foo Bar Is A Really Really Long String".to_string();
+///     let mock_string: &str = "Foo Bar Is A Really Really Long String";
 ///     let asserted_bool: bool = is_foreign_key(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::suffix::foreignkey::is_foreign_key;
-///     let mock_string: String = "fooBarIsAReallyReallyLongString".to_string();
+///     let mock_string: &str = "fooBarIsAReallyReallyLongString";
 ///     let asserted_bool: bool = is_foreign_key(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::suffix::foreignkey::is_foreign_key;
-///     let mock_string: String = "foo_bar_string_that_is_really_really_long".to_string();
+///     let mock_string: &str = "foo_bar_string_that_is_really_really_long";
 ///     let asserted_bool: bool = is_foreign_key(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 /// ```
 ///     use inflector::suffix::foreignkey::is_foreign_key;
-///     let mock_string: String = "foo_bar_string_that_is_really_really_long_id".to_string();
+///     let mock_string: &str = "foo_bar_string_that_is_really_really_long_id";
 ///     let asserted_bool: bool = is_foreign_key(mock_string);
 ///     assert!(asserted_bool == true);
 ///
 /// ```
-pub fn is_foreign_key(test_string: String) -> bool {
+pub fn is_foreign_key(test_string: &str) -> bool {
     to_foreign_key(test_string.clone()) == test_string
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -109,35 +109,35 @@ gated_str_tests![
 ];
 
 string_tests![
-    string_to_camel => to_camel_case => "foo_bar" => "fooBar".to_string(),
-    string_is_camel => is_camel_case => "fooBar" => true,
-    string_to_screaming_snake => to_screaming_snake_case => "fooBar" => "FOO_BAR".to_string(),
-    string_is_screaming_snake => is_screaming_snake_case => "FOO_BAR" => true,
-    string_to_snake => to_snake_case => "fooBar" => "foo_bar".to_string(),
-    string_is_snake => is_snake_case => "foo_bar" => true,
-    string_to_kebab => to_kebab_case => "fooBar" => "foo-bar".to_string(),
-    string_is_kebab => is_kebab_case => "foo-bar" => true,
-    string_to_train => to_train_case => "fooBar" => "Foo-Bar".to_string(),
-    string_is_train => is_train_case => "Foo-Bar" => true,
-    string_to_sentence => to_sentence_case => "fooBar" => "Foo bar".to_string(),
-    string_is_sentence => is_sentence_case => "Foo bar" => true,
-    string_to_title => to_title_case => "fooBar" => "Foo Bar".to_string(),
-    string_is_title => is_title_case => "Foo Bar" => true,
-    string_ordinalize  => ordinalize => "1" => "1st".to_string(),
-    string_deordinalize  => deordinalize => "1st" => "1".to_string(),
-    string_to_foreign_key => to_foreign_key => "Foo::Bar" => "bar_id".to_string(),
-    string_is_foreign_key => is_foreign_key => "bar_id" => true
+    string_to_camel => to_camel_case => "foo_bar".to_string() => "fooBar".to_string(),
+    string_is_camel => is_camel_case => "fooBar".to_string() => true,
+    string_to_screaming_snake => to_screaming_snake_case => "fooBar".to_string() => "FOO_BAR".to_string(),
+    string_is_screaming_snake => is_screaming_snake_case => "FOO_BAR".to_string() => true,
+    string_to_snake => to_snake_case => "fooBar".to_string() => "foo_bar".to_string(),
+    string_is_snake => is_snake_case => "foo_bar".to_string() => true,
+    string_to_kebab => to_kebab_case => "fooBar".to_string() => "foo-bar".to_string(),
+    string_is_kebab => is_kebab_case => "foo-bar".to_string() => true,
+    string_to_train => to_train_case => "fooBar".to_string() => "Foo-Bar".to_string(),
+    string_is_train => is_train_case => "Foo-Bar".to_string() => true,
+    string_to_sentence => to_sentence_case => "fooBar".to_string() => "Foo bar".to_string(),
+    string_is_sentence => is_sentence_case => "Foo bar".to_string() => true,
+    string_to_title => to_title_case => "fooBar".to_string() => "Foo Bar".to_string(),
+    string_is_title => is_title_case => "Foo Bar".to_string() => true,
+    string_ordinalize  => ordinalize => "1".to_string() => "1st".to_string(),
+    string_deordinalize  => deordinalize => "1st".to_string() => "1".to_string(),
+    string_to_foreign_key => to_foreign_key => "Foo::Bar".to_string() => "bar_id".to_string(),
+    string_is_foreign_key => is_foreign_key => "bar_id".to_string() => true
 ];
 
 gated_string_tests![
-    string_to_class => to_class_case => "foo" => "Foo".to_string(),
-    string_is_class => is_class_case => "Foo" => true,
-    string_to_table => to_table_case => "fooBar" => "foo_bars".to_string(),
-    string_is_table => is_table_case => "foo_bars" => true,
-    string_pluralize => to_plural => "crate" => "crates".to_string(),
-    string_singular => to_singular => "crates" => "crate".to_string(),
-    string_demodulize => demodulize => "Foo::Bar" => "Bar".to_string(),
-    string_deconstantize => deconstantize => "Foo::Bar" => "Foo".to_string()
+    string_to_class => to_class_case => "foo".to_string() => "Foo".to_string(),
+    string_is_class => is_class_case => "Foo".to_string() => true,
+    string_to_table => to_table_case => "fooBar".to_string() => "foo_bars".to_string(),
+    string_is_table => is_table_case => "foo_bars".to_string() => true,
+    string_pluralize => to_plural => "crate".to_string() => "crates".to_string(),
+    string_singular => to_singular => "crates".to_string() => "crate".to_string(),
+    string_demodulize => demodulize => "Foo::Bar".to_string() => "Bar".to_string(),
+    string_deconstantize => deconstantize => "Foo::Bar".to_string() => "Foo".to_string()
 ];
 
 number_tests![


### PR DESCRIPTION
# What it does:
- Changes API to act on `&str` by default

# Why it does it:
- Most of the conversions can be completed by acting on `&str`. This leads to a significant performance improvement over acting on `String` types directly.

# Related issues:
- Closes #47 

# Benchmarks:
```shell
test cases::camelcase::tests::bench_camel0                      ... bench:         132 ns/iter (+/- 15)
test cases::camelcase::tests::bench_camel1                      ... bench:         130 ns/iter (+/- 69)
test cases::camelcase::tests::bench_camel2                      ... bench:         133 ns/iter (+/- 21)
test cases::camelcase::tests::bench_is_camel                    ... bench:         127 ns/iter (+/- 21)
test cases::classcase::tests::bench_class_case                  ... bench:       2,605 ns/iter (+/- 1,422)
test cases::classcase::tests::bench_class_from_snake            ... bench:       2,474 ns/iter (+/- 1,400)
test cases::classcase::tests::bench_is_class                    ... bench:       2,447 ns/iter (+/- 279)
test cases::kebabcase::tests::bench_is_kebab                    ... bench:         151 ns/iter (+/- 29)
test cases::kebabcase::tests::bench_kebab                       ... bench:         156 ns/iter (+/- 25)
test cases::kebabcase::tests::bench_kebab_from_snake            ... bench:         254 ns/iter (+/- 54)
test cases::pascalcase::tests::bench_is_pascal                  ... bench:         129 ns/iter (+/- 17)
test cases::pascalcase::tests::bench_pascal0                    ... bench:         137 ns/iter (+/- 13)
test cases::pascalcase::tests::bench_pascal1                    ... bench:         135 ns/iter (+/- 50)
test cases::pascalcase::tests::bench_pascal2                    ... bench:         130 ns/iter (+/- 64)
test cases::screamingsnakecase::tests::bench_is_screaming_snake ... bench:         172 ns/iter (+/- 34)
test cases::screamingsnakecase::tests::bench_screaming_snake    ... bench:         177 ns/iter (+/- 21)
test cases::sentencecase::tests::bench_is_sentence              ... bench:         135 ns/iter (+/- 37)
test cases::sentencecase::tests::bench_sentence                 ... bench:         175 ns/iter (+/- 92)
test cases::sentencecase::tests::bench_sentence_from_snake      ... bench:         132 ns/iter (+/- 24)
test cases::snakecase::tests::bench_is_snake                    ... bench:         153 ns/iter (+/- 32)
test cases::snakecase::tests::bench_snake_from_camel            ... bench:         140 ns/iter (+/- 72)
test cases::snakecase::tests::bench_snake_from_snake            ... bench:         260 ns/iter (+/- 75)
test cases::snakecase::tests::bench_snake_from_title            ... bench:         149 ns/iter (+/- 72)
test cases::tablecase::tests::bench_is_table_case               ... bench:       2,453 ns/iter (+/- 401)
test cases::tablecase::tests::bench_table_case                  ... bench:       2,456 ns/iter (+/- 205)
test cases::titlecase::tests::bench_is_title                    ... bench:         133 ns/iter (+/- 59)
test cases::titlecase::tests::bench_title                       ... bench:         184 ns/iter (+/- 71)
test cases::titlecase::tests::bench_title_from_snake            ... bench:         133 ns/iter (+/- 40)
test cases::traincase::tests::bench_is_train                    ... bench:         143 ns/iter (+/- 86)
test cases::traincase::tests::bench_train                       ... bench:         129 ns/iter (+/- 25)
test cases::traincase::tests::bench_train_from_snake            ... bench:         246 ns/iter (+/- 125)
test tests::benchmark_str_deconstantize                         ... bench:       2,580 ns/iter (+/- 1,151)
test tests::benchmark_str_demodulize                            ... bench:       2,587 ns/iter (+/- 1,497)
test tests::benchmark_str_deordinalize                          ... bench:         125 ns/iter (+/- 24)
test tests::benchmark_str_is_camel                              ... bench:         133 ns/iter (+/- 19)
test tests::benchmark_str_is_class                              ... bench:       2,350 ns/iter (+/- 656)
test tests::benchmark_str_is_foreign_key                        ... bench:         228 ns/iter (+/- 57)
test tests::benchmark_str_is_kebab                              ... bench:         159 ns/iter (+/- 62)
test tests::benchmark_str_is_screaming_snake                    ... bench:         162 ns/iter (+/- 37)
test tests::benchmark_str_is_sentence                           ... bench:         135 ns/iter (+/- 44)
test tests::benchmark_str_is_snake                              ... bench:         152 ns/iter (+/- 21)
test tests::benchmark_str_is_table                              ... bench:       2,918 ns/iter (+/- 426)
test tests::benchmark_str_is_title                              ... bench:         133 ns/iter (+/- 45)
test tests::benchmark_str_is_train                              ... bench:         137 ns/iter (+/- 77)
test tests::benchmark_str_ordinalize                            ... bench:         129 ns/iter (+/- 25)
test tests::benchmark_str_pluralize                             ... bench:       2,282 ns/iter (+/- 577)
test tests::benchmark_str_singular                              ... bench:       2,690 ns/iter (+/- 568)
test tests::benchmark_str_to_camel                              ... bench:         127 ns/iter (+/- 33)
test tests::benchmark_str_to_class                              ... bench:       2,346 ns/iter (+/- 756)
test tests::benchmark_str_to_foreign_key                        ... bench:         435 ns/iter (+/- 2)
test tests::benchmark_str_to_kebab                              ... bench:         137 ns/iter (+/- 52)
test tests::benchmark_str_to_screaming_snake                    ... bench:         157 ns/iter (+/- 51)
test tests::benchmark_str_to_sentence                           ... bench:         138 ns/iter (+/- 3)
test tests::benchmark_str_to_snake                              ... bench:         137 ns/iter (+/- 33)
test tests::benchmark_str_to_table                              ... bench:       2,470 ns/iter (+/- 1,092)
test tests::benchmark_str_to_title                              ... bench:         139 ns/iter (+/- 14)
test tests::benchmark_str_to_train                              ... bench:         132 ns/iter (+/- 31)
test tests::benchmark_string_deconstantize                      ... bench:       2,610 ns/iter (+/- 1,451)
test tests::benchmark_string_demodulize                         ... bench:       2,767 ns/iter (+/- 2,864)
test tests::benchmark_string_deordinalize                       ... bench:         149 ns/iter (+/- 48)
test tests::benchmark_string_is_camel                           ... bench:         145 ns/iter (+/- 26)
test tests::benchmark_string_is_class                           ... bench:       2,380 ns/iter (+/- 183)
test tests::benchmark_string_is_foreign_key                     ... bench:         244 ns/iter (+/- 113)
test tests::benchmark_string_is_kebab                           ... bench:         194 ns/iter (+/- 113)
test tests::benchmark_string_is_screaming_snake                 ... bench:         194 ns/iter (+/- 30)
test tests::benchmark_string_is_sentence                        ... bench:         157 ns/iter (+/- 34)
test tests::benchmark_string_is_snake                           ... bench:         171 ns/iter (+/- 46)
test tests::benchmark_string_is_table                           ... bench:       2,944 ns/iter (+/- 91)
test tests::benchmark_string_is_title                           ... bench:         157 ns/iter (+/- 90)
test tests::benchmark_string_is_train                           ... bench:         165 ns/iter (+/- 87)
test tests::benchmark_string_ordinalize                         ... bench:         155 ns/iter (+/- 58)
test tests::benchmark_string_pluralize                          ... bench:       2,317 ns/iter (+/- 1,330)
test tests::benchmark_string_singular                           ... bench:       2,719 ns/iter (+/- 17)
test tests::benchmark_string_to_camel                           ... bench:         142 ns/iter (+/- 46)
test tests::benchmark_string_to_class                           ... bench:       2,376 ns/iter (+/- 486)
test tests::benchmark_string_to_foreign_key                     ... bench:         455 ns/iter (+/- 88)
test tests::benchmark_string_to_kebab                           ... bench:         163 ns/iter (+/- 48)
test tests::benchmark_string_to_screaming_snake                 ... bench:         185 ns/iter (+/- 78)
test tests::benchmark_string_to_sentence                        ... bench:         147 ns/iter (+/- 4)
test tests::benchmark_string_to_snake                           ... bench:         165 ns/iter (+/- 23)
test tests::benchmark_string_to_table                           ... bench:       2,489 ns/iter (+/- 833)
test tests::benchmark_string_to_title                           ... bench:         147 ns/iter (+/- 41)
test tests::benchmark_string_to_train                           ... bench:         158 ns/iter (+/- 73)
```
