### PR TITLE
Fixes an issue were casing will try to do non alphanumeric characters

### DIFF
--- a/src/cases/case/mod.rs
+++ b/src/cases/case/mod.rs
@@ -121,7 +121,7 @@ fn next_or_previous_char_is_lowercase(convertable_string: &str, char_with_index:
 }
 
 fn char_is_uppercase(test_char: char) -> bool {
-    test_char == test_char.to_ascii_uppercase()
+    test_char.is_alphanumeric() && test_char == test_char.to_ascii_uppercase()
 }
 
 #[allow(unused_macros)]
@@ -222,6 +222,11 @@ fn test_char_is_uppercase_when_it_is() {
 #[test]
 fn test_char_is_uppercase_when_it_is_not() {
     assert_eq!(char_is_uppercase('a'), false)
+}
+
+#[test]
+fn test_char_is_uppercase_when_it_is_not_alphanumeric() {
+    assert_eq!(char_is_uppercase('/'), false)
 }
 
 #[test]


### PR DESCRIPTION
# What it does:
Before the change

"thisIsApath/with_stuff".to_snake_case() -> "this_is_a_path_/_with_stuff"

After

"thisIsApath/with_stuff"".to_snake_case() -> "this_is_a_path/with_stuff"


# Why it does it:
It's a bug.

# Related issues:
None that I know.


Let me know if you need other tests, could not find the appropiate place for them.