### PR TITLE
Fix for invalid chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 0.11.0
 
+## Breaking changes:
+- Made snake case deal correctly with special characters. Behaviour now follows
+  rails infector
+
 ## Non-breaking changes:
 - Removed magic macros for testing.
 - Added explict tests for all cases.

--- a/src/cases/snakecase/mod.rs
+++ b/src/cases/snakecase/mod.rs
@@ -236,6 +236,55 @@ mod tests {
     }
 
     #[test]
+    fn from_case_with_loads_of_space() {
+        let convertable_string: String = "foo           bar".to_owned();
+        let expected: String = "foo_bar".to_owned();
+        assert_eq!(to_snake_case(&convertable_string), expected)
+    }
+
+    #[test]
+    fn a_name_with_a_dot() {
+        let convertable_string: String = "Robert C. Martin".to_owned();
+        let expected: String = "robert_c_martin".to_owned();
+        assert_eq!(to_snake_case(&convertable_string), expected)
+    }
+
+    #[test]
+    fn random_text_with_bad_chars() {
+        let convertable_string: String = "Random text with *(bad) chars".to_owned();
+        let expected: String = "random_text_with_bad_chars".to_owned();
+        assert_eq!(to_snake_case(&convertable_string), expected)
+    }
+
+    #[test]
+    fn trailing_bad_chars() {
+        let convertable_string: String = "trailing bad_chars*(()())".to_owned();
+        let expected: String = "trailing_bad_chars".to_owned();
+        assert_eq!(to_snake_case(&convertable_string), expected)
+    }
+
+    #[test]
+    fn leading_bad_chars() {
+        let convertable_string: String = "-!#$%leading bad chars".to_owned();
+        let expected: String = "leading_bad_chars".to_owned();
+        assert_eq!(to_snake_case(&convertable_string), expected)
+    }
+
+    #[test]
+    fn wrapped_in_bad_chars() {
+        let convertable_string: String = "-!#$%wrapped in bad chars&*^*&(&*^&(<><?>><?><>))".to_owned();
+        let expected: String = "wrapped_in_bad_chars".to_owned();
+        assert_eq!(to_snake_case(&convertable_string), expected)
+    }
+
+    #[test]
+    fn has_a_sign() {
+        let convertable_string: String = "has a + sign".to_owned();
+        let expected: String = "has_a_sign".to_owned();
+        assert_eq!(to_snake_case(&convertable_string), expected)
+    }
+
+    #[test]
     fn is_correct_from_camel_case() {
         let convertable_string: String = "fooBar".to_owned();
         assert_eq!(is_snake_case(&convertable_string), false)


### PR DESCRIPTION
# What it does:

```
foo\bar
foo\ bar
fooBar\!@#!#
foo                         bar
```

To return

`foo_bar`

# Why it does it:
- We were not handling some strings correctly


# Related issues:
Closes #55 

# NB:
- This will be slower since we're doing another iteration to remove invalid chars on the right