### PR TITLE
Fixed up unused import causing failures on nightly Rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.11.1
+
+## Non-breaking changes:
+- Removed unused case import to prevent a failure on nightly Rust
+
 # 0.11.0
 
 ## Breaking changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # 0.11.1
 
 ## Non-breaking changes:
+- Fixed an issue where words ending in e.g. "-ches", such as "witches"; that
+  would be singularized as "wit" instead of the expected "witch". -- Thanks nbaksalyar
+
+## Non-breaking changes:
 - Will be removing ascii import when current nightly goes stable.
 
 # 0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.11.1
 
 ## Non-breaking changes:
-- Removed unused case import to prevent a failure on nightly Rust
+- Will be removing ascii import when current nightly goes stable.
 
 # 0.11.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Inflector"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Josh Teeter<joshteeter@gmail.com>"]
 exclude = [".travis.yml", ".gitignore"]
 readme = "README.md"

--- a/src/cases/case/mod.rs
+++ b/src/cases/case/mod.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-use std::ascii::*;
 
 pub struct CamelOptions {
     pub new_word: bool,

--- a/src/cases/case/mod.rs
+++ b/src/cases/case/mod.rs
@@ -1,4 +1,7 @@
 #![deny(warnings)]
+#[allow(unknown_lints)]
+#[allow(unused_imports)]
+use std::ascii::*;
 
 pub struct CamelOptions {
     pub new_word: bool,


### PR DESCRIPTION
# What it does:
- Removes the ascii import on case

# Why it does it:
- It was unused and failed on new nightly rust

# Related issues:
NA
