### PR TITLE
Resolves #61 - Module classcases

### DIFF
--- a/src/cases/classcases/mod.rs
+++ b/src/cases/classcases/mod.rs
@@ -1,384 +1,384 @@
 #![deny(warnings)]
-#[cfg(feature = "heavyweight")]
-use string::singularize::to_singular;
-#[cfg(feature = "heavyweight")]
-/// Converts a `&str` to `ClassCase` `String`
+use cases::case::*;
+/// Converts a `&str` to `ClassCases` `String`
 ///
 /// ```
-///     use inflector::cases::classcase::to_class_case;
+///     use inflector::cases::classcases::to_class_cases;
 ///     let mock_string: &str = "FooBar";
 ///     let expected_string: String = "FooBar".to_string();
-///     let asserted_string: String = to_class_case(mock_string);
+///     let asserted_string: String = to_class_cases(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
 ///
 /// ```
-///     use inflector::cases::classcase::to_class_case;
+///     use inflector::cases::classcases::to_class_cases;
 ///     let mock_string: &str = "FooBars";
-///     let expected_string: String = "FooBar".to_string();
-///     let asserted_string: String = to_class_case(mock_string);
+///     let expected_string: String = "FooBars".to_string();
+///     let asserted_string: String = to_class_cases(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
 ///
 /// ```
-///     use inflector::cases::classcase::to_class_case;
+///     use inflector::cases::classcases::to_class_cases;
 ///     let mock_string: &str = "Foo Bar";
 ///     let expected_string: String = "FooBar".to_string();
-///     let asserted_string: String = to_class_case(mock_string);
+///     let asserted_string: String = to_class_cases(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
 ///
 /// ```
-///     use inflector::cases::classcase::to_class_case;
+///     use inflector::cases::classcases::to_class_cases;
 ///     let mock_string: &str = "foo-bar";
 ///     let expected_string: String = "FooBar".to_string();
-///     let asserted_string: String = to_class_case(mock_string);
+///     let asserted_string: String = to_class_cases(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
 ///
 /// ```
-///     use inflector::cases::classcase::to_class_case;
+///     use inflector::cases::classcases::to_class_cases;
 ///     let mock_string: &str = "fooBar";
 ///     let expected_string: String = "FooBar".to_string();
-///     let asserted_string: String = to_class_case(mock_string);
+///     let asserted_string: String = to_class_cases(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
 ///
 /// ```
-///     use inflector::cases::classcase::to_class_case;
+///     use inflector::cases::classcases::to_class_cases;
 ///     let mock_string: &str = "FOO_BAR";
 ///     let expected_string: String = "FooBar".to_string();
-///     let asserted_string: String = to_class_case(mock_string);
+///     let asserted_string: String = to_class_cases(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
 ///
 /// ```
-///     use inflector::cases::classcase::to_class_case;
+///     use inflector::cases::classcases::to_class_cases;
 ///     let mock_string: &str = "foo_bar";
 ///     let expected_string: String = "FooBar".to_string();
-///     let asserted_string: String = to_class_case(mock_string);
+///     let asserted_string: String = to_class_cases(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
 ///
 /// ```
-///     use inflector::cases::classcase::to_class_case;
+///     use inflector::cases::classcases::to_class_cases;
 ///     let mock_string: &str = "foo_bars";
-///     let expected_string: String = "FooBar".to_string();
-///     let asserted_string: String = to_class_case(mock_string);
+///     let expected_string: String = "FooBars".to_string();
+///     let asserted_string: String = to_class_cases(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
 ///
 /// ```
-///     use inflector::cases::classcase::to_class_case;
+///     use inflector::cases::classcases::to_class_cases;
 ///     let mock_string: &str = "Foo bar";
 ///     let expected_string: String = "FooBar".to_string();
-///     let asserted_string: String = to_class_case(mock_string);
+///     let asserted_string: String = to_class_cases(mock_string);
 ///     assert!(asserted_string == expected_string);
 ///
 /// ```
-pub fn to_class_case(non_class_case_string: &str) -> String {
-    let class_plural = super::classcases::to_class_cases(non_class_case_string);
-    let split: (&str, &str) =
-        class_plural.split_at(class_plural.rfind(char::is_uppercase).unwrap_or(0));
-    format!("{}{}", split.0, to_singular(split.1))
+pub fn to_class_cases(non_class_cases_string: &str) -> String {
+    let options = CamelOptions {
+        new_word: true,
+        last_char: ' ',
+        first_word: false,
+        injectable_char: ' ',
+        has_seperator: false,
+        inverted: false,
+    };
+    to_case_camel_like(non_class_cases_string, options)
 }
 
-#[cfg(feature = "heavyweight")]
-/// Determines if a `&str` is `ClassCase` `bool`
+/// Determines if a `&str` is `ClassCases` `bool`
 ///
 /// ```
-///     use inflector::cases::classcase::is_class_case;
+///     use inflector::cases::classcases::is_class_cases;
 ///     let mock_string: &str = "Foo";
-///     let asserted_bool: bool = is_class_case(mock_string);
+///     let asserted_bool: bool = is_class_cases(mock_string);
 ///     assert!(asserted_bool == true);
 ///
 /// ```
 ///
 /// ```
-///     use inflector::cases::classcase::is_class_case;
+///     use inflector::cases::classcases::is_class_cases;
 ///     let mock_string: &str = "foo";
-///     let asserted_bool: bool = is_class_case(mock_string);
+///     let asserted_bool: bool = is_class_cases(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 ///
 /// ```
-///     use inflector::cases::classcase::is_class_case;
+///     use inflector::cases::classcases::is_class_cases;
 ///     let mock_string: &str = "FooBarIsAReallyReallyLongStrings";
-///     let asserted_bool: bool = is_class_case(mock_string);
-///     assert!(asserted_bool == false);
+///     let asserted_bool: bool = is_class_cases(mock_string);
+///     assert!(asserted_bool == true);
 ///
 /// ```
 ///
 ///
 /// ```
-///     use inflector::cases::classcase::is_class_case;
+///     use inflector::cases::classcases::is_class_cases;
 ///     let mock_string: &str = "FooBarIsAReallyReallyLongString";
-///     let asserted_bool: bool = is_class_case(mock_string);
+///     let asserted_bool: bool = is_class_cases(mock_string);
 ///     assert!(asserted_bool == true);
 ///
 /// ```
 ///
 /// ```
-///     use inflector::cases::classcase::is_class_case;
+///     use inflector::cases::classcases::is_class_cases;
 ///     let mock_string: &str = "foo-bar-string-that-is-really-really-long";
-///     let asserted_bool: bool = is_class_case(mock_string);
+///     let asserted_bool: bool = is_class_cases(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 ///
 /// ```
-///     use inflector::cases::classcase::is_class_case;
+///     use inflector::cases::classcases::is_class_cases;
 ///     let mock_string: &str = "foo_bar_is_a_really_really_long_strings";
-///     let asserted_bool: bool = is_class_case(mock_string);
+///     let asserted_bool: bool = is_class_cases(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 ///
 ///
 /// ```
-///     use inflector::cases::classcase::is_class_case;
+///     use inflector::cases::classcases::is_class_cases;
 ///     let mock_string: &str = "fooBarIsAReallyReallyLongString";
-///     let asserted_bool: bool = is_class_case(mock_string);
+///     let asserted_bool: bool = is_class_cases(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 ///
 /// ```
-///     use inflector::cases::classcase::is_class_case;
+///     use inflector::cases::classcases::is_class_cases;
 ///     let mock_string: &str = "FOO_BAR_STRING_THAT_IS_REALLY_REALLY_LONG";
-///     let asserted_bool: bool = is_class_case(mock_string);
+///     let asserted_bool: bool = is_class_cases(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 ///
 /// ```
-///     use inflector::cases::classcase::is_class_case;
+///     use inflector::cases::classcases::is_class_cases;
 ///     let mock_string: &str = "foo_bar_string_that_is_really_really_long";
-///     let asserted_bool: bool = is_class_case(mock_string);
+///     let asserted_bool: bool = is_class_cases(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 ///
 /// ```
-///     use inflector::cases::classcase::is_class_case;
+///     use inflector::cases::classcases::is_class_cases;
 ///     let mock_string: &str = "Foo bar string that is really really long";
-///     let asserted_bool: bool = is_class_case(mock_string);
+///     let asserted_bool: bool = is_class_cases(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
 ///
 /// ```
-///     use inflector::cases::classcase::is_class_case;
+///     use inflector::cases::classcases::is_class_cases;
 ///     let mock_string: &str = "Foo Bar Is A Really Really Long String";
-///     let asserted_bool: bool = is_class_case(mock_string);
+///     let asserted_bool: bool = is_class_cases(mock_string);
 ///     assert!(asserted_bool == false);
 ///
 /// ```
-pub fn is_class_case(test_string: &str) -> bool {
-    to_class_case(&test_string.clone()) == test_string
+pub fn is_class_cases(test_string: &str) -> bool {
+    to_class_cases(&test_string.clone()) == test_string
 }
 
 #[cfg(all(feature = "unstable", test))]
-#[cfg(feature = "heavyweight")]
 mod benchmarks {
     extern crate test;
     use self::test::Bencher;
 
     #[bench]
-    fn bench_class_case(b: &mut Bencher) {
-        b.iter(|| super::to_class_case("Foo bar"));
+    fn bench_class_cases(b: &mut Bencher) {
+        b.iter(|| super::to_class_cases("Foo bar"));
     }
 
     #[bench]
     fn bench_is_class(b: &mut Bencher) {
-        b.iter(|| super::is_class_case("Foo bar"));
+        b.iter(|| super::is_class_cases("Foo bar"));
     }
 
     #[bench]
     fn bench_class_from_snake(b: &mut Bencher) {
-        b.iter(|| super::to_class_case("foo_bar"));
+        b.iter(|| super::to_class_cases("foo_bar"));
     }
 }
 
 #[cfg(test)]
-#[cfg(feature = "heavyweight")]
 mod tests {
-    use ::to_class_case;
-    use ::is_class_case;
+    use ::to_class_cases;
+    use ::is_class_cases;
 
     #[test]
     fn from_camel_case() {
         let convertable_string: String = "fooBar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_cases(&convertable_string), expected)
     }
 
     #[test]
     fn from_pascal_case() {
         let convertable_string: String = "FooBar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_cases(&convertable_string), expected)
     }
 
     #[test]
     fn from_kebab_case() {
         let convertable_string: String = "foo-bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_cases(&convertable_string), expected)
     }
 
     #[test]
     fn from_sentence_case() {
         let convertable_string: String = "Foo bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_cases(&convertable_string), expected)
     }
 
     #[test]
     fn from_title_case() {
         let convertable_string: String = "Foo Bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_cases(&convertable_string), expected)
     }
 
     #[test]
     fn from_train_case() {
         let convertable_string: String = "Foo-Bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_cases(&convertable_string), expected)
     }
 
     #[test]
-    fn from_screaming_class_case() {
+    fn from_screaming_class_cases() {
         let convertable_string: String = "FOO_BAR".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_cases(&convertable_string), expected)
     }
 
     #[test]
     fn from_snake_case() {
         let convertable_string: String = "foo_bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_cases(&convertable_string), expected)
     }
 
     #[test]
     fn from_table_case() {
         let convertable_string: String = "foo_bars".to_owned();
-        let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        let expected: String = "FooBars".to_owned();
+        assert_eq!(to_class_cases(&convertable_string), expected)
     }
 
     #[test]
     fn from_case_with_loads_of_space() {
         let convertable_string: String = "foo           bar".to_owned();
         let expected: String = "FooBar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_cases(&convertable_string), expected)
     }
 
     #[test]
     fn a_name_with_a_dot() {
         let convertable_string: String = "Robert C. Martin".to_owned();
         let expected: String = "RobertCMartin".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_cases(&convertable_string), expected)
     }
 
     #[test]
     fn random_text_with_bad_chars() {
         let convertable_string: String = "Random text with *(bad) chars".to_owned();
-        let expected: String = "RandomTextWithBadChar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        let expected: String = "RandomTextWithBadChars".to_owned();
+        assert_eq!(to_class_cases(&convertable_string), expected)
     }
 
     #[test]
     fn trailing_bad_chars() {
         let convertable_string: String = "trailing bad_chars*(()())".to_owned();
-        let expected: String = "TrailingBadChar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        let expected: String = "TrailingBadChars".to_owned();
+        assert_eq!(to_class_cases(&convertable_string), expected)
     }
 
     #[test]
     fn leading_bad_chars() {
         let convertable_string: String = "-!#$%leading bad chars".to_owned();
-        let expected: String = "LeadingBadChar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        let expected: String = "LeadingBadChars".to_owned();
+        assert_eq!(to_class_cases(&convertable_string), expected)
     }
 
     #[test]
     fn wrapped_in_bad_chars() {
         let convertable_string: String = "-!#$%wrapped in bad chars&*^*&(&*^&(<><?>><?><>))".to_owned();
-        let expected: String = "WrappedInBadChar".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        let expected: String = "WrappedInBadChars".to_owned();
+        assert_eq!(to_class_cases(&convertable_string), expected)
     }
 
     #[test]
     fn has_a_sign() {
         let convertable_string: String = "has a + sign".to_owned();
         let expected: String = "HasASign".to_owned();
-        assert_eq!(to_class_case(&convertable_string), expected)
+        assert_eq!(to_class_cases(&convertable_string), expected)
     }
 
     #[test]
-    fn is_correct_from_class_case() {
+    fn is_correct_from_class_cases() {
         let convertable_string: String = "fooBar".to_owned();
-        assert_eq!(is_class_case(&convertable_string), false)
+        assert_eq!(is_class_cases(&convertable_string), false)
     }
 
     #[test]
     fn is_correct_from_pascal_case() {
         let convertable_string: String = "FooBar".to_owned();
-        assert_eq!(is_class_case(&convertable_string), true)
+        assert_eq!(is_class_cases(&convertable_string), true)
     }
 
     #[test]
     fn is_correct_from_kebab_case() {
         let convertable_string: String = "foo-bar".to_owned();
-        assert_eq!(is_class_case(&convertable_string), false)
+        assert_eq!(is_class_cases(&convertable_string), false)
     }
 
     #[test]
     fn is_correct_from_sentence_case() {
         let convertable_string: String = "Foo bar".to_owned();
-        assert_eq!(is_class_case(&convertable_string), false)
+        assert_eq!(is_class_cases(&convertable_string), false)
     }
 
     #[test]
     fn is_correct_from_title_case() {
         let convertable_string: String = "Foo Bar".to_owned();
-        assert_eq!(is_class_case(&convertable_string), false)
+        assert_eq!(is_class_cases(&convertable_string), false)
     }
 
     #[test]
     fn is_correct_from_train_case() {
         let convertable_string: String = "Foo-Bar".to_owned();
-        assert_eq!(is_class_case(&convertable_string), false)
+        assert_eq!(is_class_cases(&convertable_string), false)
     }
 
     #[test]
     fn is_correct_from_screaming_snake_case() {
         let convertable_string: String = "FOO_BAR".to_owned();
-        assert_eq!(is_class_case(&convertable_string), false)
+        assert_eq!(is_class_cases(&convertable_string), false)
     }
 
     #[test]
     fn is_correct_from_snake_case() {
         let convertable_string: String = "foo_bar".to_owned();
-        assert_eq!(is_class_case(&convertable_string), false)
+        assert_eq!(is_class_cases(&convertable_string), false)
     }
 
     #[test]
     fn is_correct_from_table_case() {
         let convertable_string: String = "FooBar".to_owned();
-        assert_eq!(is_class_case(&convertable_string), true)
+        assert_eq!(is_class_cases(&convertable_string), true)
     }
 }
 

--- a/src/cases/mod.rs
+++ b/src/cases/mod.rs
@@ -1,8 +1,17 @@
 mod case;
 /// Provides conversion to and detection of class case strings.
 ///
+/// This version singularizes strings.
+///
 /// Example string `ClassCase`
 pub mod classcase;
+
+/// Provides conversion to and detection of class case strings.
+///
+/// This variant accepts plurals for strings.
+///
+/// Example string `ClassCases`
+pub mod classcases;
 
 /// Provides conversion to and detection of camel case strings.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,9 @@ use cases::classcase::to_class_case;
 #[cfg(feature = "heavyweight")]
 use cases::classcase::is_class_case;
 
+use cases::classcases::to_class_cases;
+use cases::classcases::is_class_cases;
+
 use cases::camelcase::to_camel_case;
 use cases::camelcase::is_camel_case;
 
@@ -137,6 +140,10 @@ pub trait Inflector {
     fn to_class_case(&self) -> String;
     #[cfg(feature = "heavyweight")]
     fn is_class_case(&self) -> bool;
+
+    fn to_class_cases(&self) -> String;
+    fn is_class_cases(&self) -> bool;
+
     #[cfg(feature = "heavyweight")]
     fn to_table_case(&self) -> String;
     #[cfg(feature = "heavyweight")]
@@ -195,6 +202,8 @@ macro_rules! implement_string_for {
                 define_implementations![self;
                     to_camel_case => String,
                     is_camel_case => bool,
+                    to_class_cases => String,
+                    is_class_cases => bool,
                     to_pascal_case => String,
                     is_pascal_case => bool,
                     to_screaming_snake_case => String,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -66,6 +66,9 @@ str_tests![
     str_to_camel => to_camel_case => "foo_bar" => "fooBar".to_string(),
     str_is_camel => is_camel_case => "fooBar" => true,
     str_is_not_camel => is_camel_case => "foo_bar" => false,
+    str_to_class_cases => to_class_cases => "foo" => "Foo".to_string(),
+    str_is_class_cases => is_class_cases => "Foo" => true,
+    str_is_not_class_cases => is_class_cases => "foo" => false,
     str_to_screaming_snake => to_screaming_snake_case => "fooBar" => "FOO_BAR".to_string(),
     str_is_screaming_snake => is_screaming_snake_case => "FOO_BAR" => true,
     str_is_not_screaming_snake => is_screaming_snake_case => "foo_bar" => false,
@@ -92,9 +95,9 @@ str_tests![
 ];
 
 gated_str_tests![
-    str_to_class => to_class_case => "foo" => "Foo".to_string(),
-    str_is_class => is_class_case => "Foo" => true,
-    str_is_not_class => is_class_case => "foo" => false,
+    str_to_class_case => to_class_case => "foo" => "Foo".to_string(),
+    str_is_class_case => is_class_case => "Foo" => true,
+    str_is_not_class_case => is_class_case => "foo" => false,
     str_to_table => to_table_case => "fooBar" => "foo_bars".to_string(),
     str_is_table => is_table_case => "foo_bars" => true,
     str_is_not_table => is_table_case => "fooBars" => false,
@@ -108,6 +111,9 @@ string_tests![
     string_to_camel => to_camel_case => "foo_bar".to_string() => "fooBar".to_string(),
     string_is_camel => is_camel_case => "fooBar".to_string() => true,
     string_is_not_camel => is_camel_case => "foo_bar".to_string() => false,
+    string_to_class_cases => to_class_cases => "foo".to_string() => "Foo".to_string(),
+    string_is_class_cases => is_class_cases => "Foo".to_string() => true,
+    string_is_not_class_cases => is_class_cases => "ooBar".to_string() => false,
     string_to_screaming_snake => to_screaming_snake_case => "fooBar".to_string() => "FOO_BAR".to_string(),
     string_is_screaming_snake => is_screaming_snake_case => "FOO_BAR".to_string() => true,
     string_is_not_screaming_snake => is_screaming_snake_case => "foo_bar".to_string() => false,
@@ -134,9 +140,9 @@ string_tests![
 ];
 
 gated_string_tests![
-    string_to_class => to_class_case => "foo".to_string() => "Foo".to_string(),
-    string_is_class => is_class_case => "Foo".to_string() => true,
-    string_is_not_class => is_class_case => "ooBar".to_string() => false,
+    string_to_class_case => to_class_case => "foo".to_string() => "Foo".to_string(),
+    string_is_class_case => is_class_case => "Foo".to_string() => true,
+    string_is_not_class_case => is_class_case => "ooBar".to_string() => false,
     string_to_table => to_table_case => "fooBar".to_string() => "foo_bars".to_string(),
     string_is_table => is_table_case => "foo_bars".to_string() => true,
     string_is_not_table => is_table_case => "fooBar".to_string() => false,


### PR DESCRIPTION
# What it does:
- Introduce a new module `classcases`, which supports a variant `ClassCase` that does not perform singularization.

# Why it does it:
- I have a code generator that depends on Inflector to perform code generation. Singularization breaks many cases in manners that are unpredictable by the user.

# Related issues:
- Issue #61.