### PR TITLE
Relicensing as BSD 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 repository = "https://github.com/whatisinternet/inflector"
 documentation = "https://docs.rs/Inflector"
 homepage = "https://github.com/whatisinternet/inflector"
-license="BSD-2-Clause"
+license="BSD-3-Clause"
 description = """
 Adds String based inflections for Rust. Snake, kebab, camel, sentence, class, title and table cases as well as ordinalize, deordinalize, demodulize, foreign key, and pluralize/singularize are supported as both traits and pure functions acting on String types.
 """

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -10,6 +10,8 @@ are permitted provided that the following conditions are met:
    this list of conditions and the following disclaimer in the documentation
 and/or other materials provided with the distribution.
 
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE


### PR DESCRIPTION
I'm having slight difficulties landing this in the Firefox tree because of licensing issues. BSD 3 has been approved by our legal, while BSD 2 hasn't yet – I know that the difference between both is trivial, I don't know how much time it will take them to realize.

So, here is a PR relicensing as BSD 3. I don't know if you have the will and/or authorization to do so, but if you do, this will save me a little headache :) It's ok if you don't, I'm sure that legal will find time to look at this in a not-too-distant future.