### PR TITLE
Update regex to 1.0 and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Inflector"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["Josh Teeter<joshteeter@gmail.com>"]
 exclude = [".travis.yml", ".gitignore"]
 readme = "README.md"
@@ -26,5 +26,5 @@ heavyweight = ['regex', 'lazy_static']
 name = "inflector"
 
 [dependencies]
-regex = {version = "0.2", optional = true}
+regex = {version = "1.0", optional = true}
 lazy_static = {version = "1.0.0", optional = true}


### PR DESCRIPTION
# What it does:
It updates regex to 1.0

# Why it does it:
Because I want to update regex to 1.0 in servo and mozilla-central

# Related issues:
