### PR TITLE
[Bug] to_class_case broken for "my_statuses" and "my_leaves"

### DIFF
--- a/src/cases/classcase/mod.rs
+++ b/src/cases/classcase/mod.rs
@@ -344,6 +344,13 @@ mod tests {
     }
 
     #[test]
+    fn has_special_singular_form_2() {
+        let convertable_string: String = "my_leaves".to_owned();
+        let expected: String = "MyLeaf".to_owned();
+        assert_eq!(to_class_case(&convertable_string), expected)
+    }
+
+    #[test]
     fn is_correct_from_class_case() {
         let convertable_string: String = "fooBar".to_owned();
         assert_eq!(is_class_case(&convertable_string), false)

--- a/src/cases/classcase/mod.rs
+++ b/src/cases/classcase/mod.rs
@@ -337,6 +337,13 @@ mod tests {
     }
 
     #[test]
+    fn has_special_singular_form() {
+        let convertable_string: String = "my_statuses".to_owned();
+        let expected: String = "MyStatus".to_owned();
+        assert_eq!(to_class_case(&convertable_string), expected)
+    }
+
+    #[test]
     fn is_correct_from_class_case() {
         let convertable_string: String = "fooBar".to_owned();
         assert_eq!(is_class_case(&convertable_string), false)


### PR DESCRIPTION
I created a test to replicate the issue I'm having:

Test failure:
```
~/workspace/Inflector - (ae-fix-bug-with-to-class-case) $ t has_special_singular_form
   Compiling Inflector v0.11.4 (/Users/alex.evanczuk/workspace/Inflector)
    Finished test [unoptimized + debuginfo] target(s) in 0.70s
     Running unittests src/lib.rs (target/debug/deps/inflector-e6853dcf653bbf92)

running 1 test
test cases::classcase::tests::has_special_singular_form ... FAILED

failures:

---- cases::classcase::tests::has_special_singular_form stdout ----
thread 'cases::classcase::tests::has_special_singular_form' panicked at 'assertion failed: `(left == right)`
  left: `"MyStatuse"`,
 right: `"MyStatus"`', src/cases/classcase/mod.rs:343:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

failures:
    cases::classcase::tests::has_special_singular_form

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 259 filtered out; finished in 0.05s

error: test failed, to rerun pass `--lib`
```

I'm a bit new to Rust so it might take me some time (having some trouble fixing myself), but I can look more next week!
